### PR TITLE
[ 공통컴포넌트 ] 드롭다운 리스트 구현

### DIFF
--- a/components/common/DropdownMenu.tsx
+++ b/components/common/DropdownMenu.tsx
@@ -1,0 +1,59 @@
+'use client';
+import React, { useState, useEffect, useRef, ComponentType, SVGProps } from 'react';
+
+interface DropdownProps {
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  dropdownList: string[];
+  onItemClick: (item: string) => void;
+}
+
+const DropdownMenu = ({ icon: Icon, dropdownList, onItemClick }: DropdownProps) => {
+  const [isDropdownOpen, setDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const toggleDropdown = () => setDropdownOpen((prev) => !prev);
+  const closeDropdown = () => setDropdownOpen(false);
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      closeDropdown();
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  return (
+    <div className='relative inline-block gap-2'>
+      <button onClick={toggleDropdown} className='p-2 rounded focus:outline-none' aria-label='더보기 메뉴 열기'>
+        <Icon width={24} height={24} />
+      </button>
+
+      {isDropdownOpen && (
+        <div
+          ref={dropdownRef}
+          className='absolute right-0 mt-2 w-auto bg-white rounded-xl shadow-[4px_4px_10px_-2px_rgba(0,0,0,0.05)] items-center'
+        >
+          <ul className='flex flex-col text-nowrap text-sm sm:text-lg lg:text-lg text-slate-700 leading-5 lg:leading-7 justify-center items-center text-center'>
+            {dropdownList.map((listItem, idx) => (
+              <li
+                key={idx}
+                className='flex justify-center items-center text-center px-4 pt-2 pb-[6px] hover:bg-gray-100 cursor-pointer first:rounded-t-xl last:rounded-b-xl'
+                onClick={() => {
+                  onItemClick(listItem);
+                  closeDropdown();
+                }}
+              >
+                {listItem}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DropdownMenu;

--- a/package-lock.json
+++ b/package-lock.json
@@ -537,14 +537,14 @@
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
       "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1349,7 +1349,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {

--- a/public/icons/IconKebab.tsx
+++ b/public/icons/IconKebab.tsx
@@ -1,0 +1,41 @@
+import React, { SVGProps } from 'react';
+
+export const IconKebab = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg xmlns='http://www.w3.org/2000/svg' width='4' height='18' viewBox='0 0 4 18' fill='none' {...props}>
+      <ellipse
+        cx='1.9'
+        cy='8.99844'
+        rx='0.9'
+        ry='0.9'
+        transform='rotate(-90 1.9 8.99844)'
+        fill='#94A3B8'
+        stroke='#94A3B8'
+        stroke-width='2'
+        stroke-linecap='round'
+      />
+      <ellipse
+        cx='1.9'
+        cy='15.7992'
+        rx='0.9'
+        ry='0.9'
+        transform='rotate(-90 1.9 15.7992)'
+        fill='#94A3B8'
+        stroke='#94A3B8'
+        stroke-width='2'
+        stroke-linecap='round'
+      />
+      <ellipse
+        cx='1.9'
+        cy='2.19961'
+        rx='0.9'
+        ry='0.9'
+        transform='rotate(-90 1.9 2.19961)'
+        fill='#94A3B8'
+        stroke='#94A3B8'
+        stroke-width='2'
+        stroke-linecap='round'
+      />
+    </svg>
+  );
+};

--- a/public/icons/IconKebabWithCircle.tsx
+++ b/public/icons/IconKebabWithCircle.tsx
@@ -1,0 +1,43 @@
+import React, { SVGProps } from 'react';
+
+export const IconKebabWithCircle = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' {...props}>
+      <circle cx='12' cy='12' r='10' fill='#F8FAFC' />
+      <g transform='translate(10, 6)'>
+        <svg xmlns='http://www.w3.org/2000/svg' width='4' height='12' viewBox='0 0 4 12' fill='none'>
+          <circle
+            cx='1.94199'
+            cy='6.00039'
+            r='0.525'
+            transform='rotate(-90 1.94199 6.00039)'
+            fill='#94A3B8'
+            stroke='#94A3B8'
+            stroke-width='1.16667'
+            stroke-linecap='round'
+          />
+          <circle
+            cx='1.94199'
+            cy='9.96719'
+            r='0.525'
+            transform='rotate(-90 1.94199 9.96719)'
+            fill='#94A3B8'
+            stroke='#94A3B8'
+            stroke-width='1.16667'
+            stroke-linecap='round'
+          />
+          <circle
+            cx='1.94199'
+            cy='2.03359'
+            r='0.525'
+            transform='rotate(-90 1.94199 2.03359)'
+            fill='#94A3B8'
+            stroke='#94A3B8'
+            stroke-width='1.16667'
+            stroke-linecap='round'
+          />
+        </svg>
+      </g>
+    </svg>
+  );
+};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->

<!-- ex) [Home] 대시보드에서 ~~ 구현 -->

## ✅ 작업 내용
할일 목록, 할 일 세부 페이지에서 사용할 케밥 아이콘의 드롭다운 메뉴를 구현했습니다.
- 아이콘 클릭시 하단에 드롭다운으로 메뉴가 생성됩니다.
- 드롭다운 메뉴 호버시 메뉴의 배경 색상이 변경됩니다.
- 반응형 디자인까지 추가되었습니다.


## 📸 스크린샷 / GIF / Link
![Kapture 2024-10-17 at 13 12 31](https://github.com/user-attachments/assets/7d5cfe4a-1927-4b28-a396-fb749db6f3fc)

