### PR TITLE
[ 공통컴포넌트 ] 모달 수정

### DIFF
--- a/components/common/Modal.tsx
+++ b/components/common/Modal.tsx
@@ -2,8 +2,11 @@
 
 import IconModalClose from '@/public/icons/IconModalClose';
 import {
+  Children,
+  cloneElement,
   ComponentPropsWithoutRef,
   createContext,
+  isValidElement,
   MouseEventHandler,
   PropsWithChildren,
   useContext,
@@ -71,12 +74,27 @@ const ModalContent = ({ className, children, ...props }: ComponentPropsWithoutRe
   );
 };
 
-const ModalClose = ({ ...props }: ComponentPropsWithoutRef<'button'>) => {
+const ModalClose = ({
+  asChild = false,
+  children,
+  ...props
+}: ComponentPropsWithoutRef<'button'> & { asChild?: boolean }) => {
   const { handleClose } = useModalContext();
+
+  if (asChild && Children.count(children) === 1 && isValidElement(children)) {
+    return cloneElement(children, {
+      ...props,
+      ...children.props,
+      onClick: () => {
+        if (children.props.onClick) children.props.onClick();
+        handleClose();
+      },
+    });
+  }
 
   return (
     <button onClick={handleClose} {...props}>
-      <IconModalClose />
+      {children ? children : <IconModalClose />}
     </button>
   );
 };

--- a/components/common/Modal.tsx
+++ b/components/common/Modal.tsx
@@ -11,6 +11,7 @@ import {
   useState,
 } from 'react';
 import { createPortal } from 'react-dom';
+import { twMerge } from 'tailwind-merge';
 
 const ModalContext = createContext({ isOpen: false, handleOpen: () => {}, handleClose: () => {} });
 
@@ -44,7 +45,7 @@ const ModalTrigger = ({ children, ...props }: ComponentPropsWithoutRef<'button'>
   );
 };
 
-const ModalContent = ({ children, ...props }: ComponentPropsWithoutRef<'div'>) => {
+const ModalContent = ({ className, children, ...props }: ComponentPropsWithoutRef<'div'>) => {
   const { isOpen, handleClose } = useModalContext();
 
   const ref = useRef<HTMLDivElement | null>(null);
@@ -60,7 +61,7 @@ const ModalContent = ({ children, ...props }: ComponentPropsWithoutRef<'div'>) =
         createPortal(
           <div className='fixed inset-0 flex justify-center items-center' onClick={handleClickOverlay}>
             <div className='absolute inset-0 bg-black opacity-50'></div>
-            <div className='p-6 rounded-xl bg-white z-10' ref={ref} {...props}>
+            <div className={twMerge('p-6 rounded-xl bg-white z-10', className)} ref={ref} {...props}>
               {children}
             </div>
           </div>,


### PR DESCRIPTION
- twMerge

<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->

<!-- ex) [Home] 대시보드에서 ~~ 구현 -->

## ✅ 작업 내용
ModalContent 컴포넌트 커스텀 가능하도록 className 프롭 추가했습니다. 
ModalClose 컴포넌트에 asChild 프롭을 추가했습니다. 
- asChild가 참일 때 자식컴포넌트에 모달 닫힘 이벤트가 전달됨.
  - 단 자식 컴포넌트가 한 개일 때만 유효함. 
  - 자식컴포넌트가 여러개일 경우 asChild의 값은 무시됩니다.

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항
Closes #27 

## ✍ 궁금한 것
