### PR TITLE
[ 공통컴포넌트 ] 드롭다운 메뉴 아이콘 크기 오류 수정

### DIFF
--- a/components/common/DropdownMenu.tsx
+++ b/components/common/DropdownMenu.tsx
@@ -5,9 +5,10 @@ interface DropdownProps {
   icon: ComponentType<SVGProps<SVGSVGElement>>;
   dropdownList: string[];
   onItemClick: (item: string) => void;
+  className?: string;
 }
 
-const DropdownMenu = ({ icon: Icon, dropdownList, onItemClick }: DropdownProps) => {
+const DropdownMenu = ({ icon: Icon, dropdownList, onItemClick, className: iconButtonClasses }: DropdownProps) => {
   const [isDropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -26,9 +27,13 @@ const DropdownMenu = ({ icon: Icon, dropdownList, onItemClick }: DropdownProps) 
   }, []);
 
   return (
-    <div className='relative inline-block gap-2'>
-      <button onClick={toggleDropdown} className='p-2 rounded focus:outline-none' aria-label='더보기 메뉴 열기'>
-        <Icon width={24} height={24} />
+    <div className='flex-col justify-center items-center relative inline-block'>
+      <button
+        onClick={toggleDropdown}
+        className='rounded focus:outline-none flex justify-center items-center'
+        aria-label='더보기 메뉴 열기'
+      >
+        <Icon width={24} height={24} className={iconButtonClasses} />
       </button>
 
       {isDropdownOpen && (
@@ -36,7 +41,7 @@ const DropdownMenu = ({ icon: Icon, dropdownList, onItemClick }: DropdownProps) 
           ref={dropdownRef}
           className='absolute right-0 mt-2 w-auto bg-white rounded-xl shadow-[4px_4px_10px_-2px_rgba(0,0,0,0.05)] items-center'
         >
-          <ul className='flex flex-col text-nowrap text-sm sm:text-lg lg:text-lg text-slate-700 leading-5 lg:leading-7 justify-center items-center text-center'>
+          <ul className='flex flex-col text-nowrap text-sm sm:text-lg lg:text-lg text-slate-700 justify-center items-center text-center'>
             {dropdownList.map((listItem, idx) => (
               <li
                 key={idx}

--- a/components/common/TodoItem/TodoIcon.tsx
+++ b/components/common/TodoItem/TodoIcon.tsx
@@ -5,7 +5,7 @@ import IconLink from '@/public/icons/IconLink';
 import IconNoteView from '@/public/icons/IconNoteView';
 import IconNoteWrite from '@/public/icons/IconNoteWrite';
 import DropdownMenu from '../DropdownMenu';
-import { IconKebab } from '@/public/icons/IconKebab';
+import { IconKebabWithCircle } from '@/public/icons/IconKebabWithCircle';
 import { TodoItemData } from '.';
 
 interface TodoIconProps {
@@ -19,13 +19,13 @@ const TodoIcon: React.FC<TodoIconProps> = ({ data }) => {
       {data.linkUrl && <IconLink className='hover:stroke-slate-100 hover:fill-slate-200 cursor-pointer' />}
       {data.noteId && <IconNoteView className='hover:stroke-slate-100 hover:fill-slate-200 cursor-pointer' />}
       <IconNoteWrite className='hover:stroke-slate-100 hover:fill-slate-200 cursor-pointer' />
-      <div>
-        <DropdownMenu
-          icon={IconKebab}
-          dropdownList={['수정하기', '삭제하기']}
-          onItemClick={(item) => console.log(item)}
-        />
-      </div>
+
+      <DropdownMenu
+        icon={IconKebabWithCircle}
+        dropdownList={['수정하기', '삭제하기']}
+        onItemClick={(item) => console.log(item)}
+        className='hover:stroke-slate-100 hover:fill-slate-200 cursor-pointer'
+      />
     </div>
   );
 };


### PR DESCRIPTION
## ✅ 작업 내용
- TodoItem 공통컴포넌트에서 dropdownMenu를 사용시 props로 적용한 아이콘이 크게 나오는 오류를 수정했습니다.
  - IconKebab 대신 IconKebabWithCircle을 사용해야합니다.
- DropdownMenu에 커스텀으로 className을 추가할 수 있도록 수정했습니다.
## 📸 스크린샷 / GIF / Link
before
![image](https://github.com/user-attachments/assets/f4133d59-8556-419f-be92-bfdca8b9e7bf)

after
![image](https://github.com/user-attachments/assets/fe558e34-c096-49bc-ac28-8431504ca44b)

