### PR TITLE
[ 공통컴포넌트 ] TodoIcon의 DropdownMenu에 className이 적용되지 않는 오류 수정

### DIFF
--- a/components/common/TodoItem/TodoIcon.tsx
+++ b/components/common/TodoItem/TodoIcon.tsx
@@ -19,13 +19,14 @@ const TodoIcon: React.FC<TodoIconProps> = ({ data }) => {
       {data.linkUrl && <IconLink className='hover:stroke-slate-100 hover:fill-slate-200 cursor-pointer' />}
       {data.noteId && <IconNoteView className='hover:stroke-slate-100 hover:fill-slate-200 cursor-pointer' />}
       <IconNoteWrite className='hover:stroke-slate-100 hover:fill-slate-200 cursor-pointer' />
-
-      <DropdownMenu
-        icon={IconKebabWithCircle}
-        dropdownList={['수정하기', '삭제하기']}
-        onItemClick={(item) => console.log(item)}
-        className='hover:stroke-slate-100 hover:fill-slate-200 cursor-pointer'
-      />
+      <div className='flex justify-center items-center'>
+        <DropdownMenu
+          icon={IconKebabWithCircle}
+          dropdownList={['수정하기', '삭제하기']}
+          onItemClick={(item) => console.log(item)}
+          className='hover:stroke-slate-100 hover:fill-slate-200 cursor-pointer transition-all duration-200 w-0 group-hover:w-auto group-focus-within:w-auto'
+        />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## ✅ 작업 내용

TodoIcon에 DropdownMenu가 있는 kebab 아이콘에서 다른 아이콘들과 달리 w-0이 적용되지 않고 hover하지 않아도 보이는 오류를 수정했습니다.
- 자식의 자식까지 style이 적용되지 않아 DropdownMenu에 직접 className을 적어야합니다.
  - DropdownMenu의 아이콘만 꺼내서 onClick으로 적용하려 했지만 코드가 더욱 복잡해져 우선 DropdownMenu에 직접 className을 입력하고, 추후 변경이 가능하다면 수정해보겠습니다.
- flex, items-center가 적용되지 않는 문제가 있어 상위에 div를 하나 더 만들어 스타일을 적용했습니다.

## 📸 스크린샷 / GIF / Link
before
![Image](https://github.com/user-attachments/assets/c0dc140f-9869-4cb8-aa09-b20ad9966a67)

after
![Kapture 2024-10-22 at 18 24 05](https://github.com/user-attachments/assets/299d632c-8bdd-4412-b57c-ee915a836ee9)

