### PR TITLE
[ 모든 할 일 페이지 ] 타입오류 고치기 및 네브 레이아웃 css 변경

### DIFF
--- a/app/(nav)/layout.tsx
+++ b/app/(nav)/layout.tsx
@@ -6,9 +6,9 @@ export default function NavLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className='flex'>
+    <div className='flex w-screen h-screen'>
       <NavBar />
-      <div>{children}</div>
+      <div className='flex-1'>{children}</div>
     </div>
   );
 }

--- a/app/(nav)/todos/page.tsx
+++ b/app/(nav)/todos/page.tsx
@@ -18,8 +18,8 @@ export default function Alltodos() {
     fetchTodos();
   }, []);
   return (
-    <div className='bg-slate-100 w-full h-screen'>
-      <main className='lg:mx-20 sm:mx-6 mx-4 my-6 max-w-[792px]'>
+    <div className='bg-slate-100 w-full h-full'>
+      <main className='lg:px-20 sm:px-6 px-4 py-6 max-w-[792px]'>
         <HeaderAllTodos length={totalCount} />
         <div className='sm:p-6 p-4 bg-white rounded-xl flex flex-col gap-4'>
           <Filters />

--- a/components/AllTodos/HeaderAllTodos.tsx
+++ b/components/AllTodos/HeaderAllTodos.tsx
@@ -1,4 +1,5 @@
 import Button from '../common/ButtonSlid';
+import { IconPlusSmall } from '@/public/icons/IconPlusSmall';
 
 interface HeaderAllTodosProps {
   length: number;
@@ -8,7 +9,8 @@ const HeaderAllTodos: React.FC<HeaderAllTodosProps> = ({ length }) => {
   return (
     <div className='mb-4 flex items-center justify-between'>
       <h1 className='text-slate-900 sm:text-lg font-semibold'>모든 할 일 ({length})</h1>
-      <Button className='border-none' variant='outlined'>
+      <Button className='border-none gap-1' variant='outlined'>
+        <IconPlusSmall stroke='#3B82F6' />
         할일 추가
       </Button>
     </div>

--- a/components/common/TodoItem/index.tsx
+++ b/components/common/TodoItem/index.tsx
@@ -16,13 +16,13 @@ export interface Goal {
 }
 
 export interface TodoItemData {
-  noteId: number;
+  noteId: number | null;
   done: boolean;
-  linkUrl: string;
-  fileUrl: string;
+  linkUrl: string | null;
+  fileUrl: string | null;
   title: string;
   id: number;
-  goal: Goal;
+  goal: Goal | null;
   userId: number;
   teamId: string;
   updatedAt: string;
@@ -47,7 +47,7 @@ const TodoItem: React.FC<TodoItemProps> = ({ data, viewGoal }) => {
           <TodoIcon data={data} />
         </div>
       </div>
-      {viewGoal && data.goal.id && <GoalTitle goal={data.goal} />}
+      {viewGoal && data.goal?.id && <GoalTitle goal={data.goal} />}
     </div>
   );
 };


### PR DESCRIPTION
close #60 

## ✅ 작업 내용
- todoitem 타입 수정
- nav가 있는 layout css 변경
```
 <div className='flex w-screen h-screen'>
      <NavBar />
      <div className='flex-1'>{children}</div>
    </div>
```
w, h가 스크린 크기만큼으로 고정 되며 네브가 차지한 나머지 구역을 전부 자식컴포넌트(페이지)가 차지


