### PR TITLE
[ 공통컴포넌트 ] 모달 수정

### DIFF
--- a/components/common/Modal.tsx
+++ b/components/common/Modal.tsx
@@ -103,6 +103,7 @@ const ModalClose = forwardRef(
           if (children.props.onClick) children.props.onClick();
           handleClose();
         },
+        ref,
       });
     }
 

--- a/components/common/Modal.tsx
+++ b/components/common/Modal.tsx
@@ -66,17 +66,19 @@ const ModalContent = ({
 
   const ref = useRef<HTMLDivElement | null>(null);
 
-  const handleClickOverlay: MouseEventHandler<HTMLDivElement> = (e) => {
+  const handleClickOverlay = () => {
     if (!closeOnClickOverlay) return;
-    e.stopPropagation();
     handleClose();
   };
+
+  if (isOpen) document.body.style.overflow = 'hidden';
+  else document.body.style.overflow = '';
 
   return (
     <>
       {isOpen &&
         createPortal(
-          <div className='fixed inset-0 flex justify-center items-center p-8'>
+          <div className='fixed inset-0 flex justify-center items-center p-8' onClick={(e) => e.stopPropagation()}>
             <div className='absolute inset-0 bg-black opacity-50' onClick={handleClickOverlay}></div>
             <div className={twMerge('p-6 rounded-xl bg-white z-10', className)} ref={ref} {...props}>
               {children}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->

<!-- ex) [Home] 대시보드에서 ~~ 구현 -->

## ✅ 작업 내용
- 기존 오버레이에 mouseup 이벤트로도 닫히던 방식을 배제 (드래그 할 때 등). 오버레이에 mousedown, mouseup 되어야만 닫힘. - 이벤트리스너를 하위 컴포넌트로 이동함

- 오버레이 클릭해도 닫히지 않도록 closeOnClickOverlay 불리언 프롭 추가

- 중첩모달이 모두 한번에 닫힐 수 있도록 ('정말 나가시겠어요?' 모달 등) ModalClose에 ref 적용

- createContext 인수를 undefined로 변경하여 useContext 사용 시 컨텍스트가 없을 경우 정상적으로 에러를 발생시킴

- useModalContext를 내보내기 했습니다. isOpen, handleOpen, handleClose 등을 가져와서 쓸 수 있습니다. 

- 모달이 열리면 백그라운드 스크롤이 막힙니다. `document.body.style.overflow = 'hidden';`

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항
Closes #102 

## ✍ 궁금한 것
