### PR TITLE
[ 할 일 ] 할 일 생성/수정 목표 선택 DropdownMenu로 변경

### DIFF
--- a/components/common/DropdownMenu.tsx
+++ b/components/common/DropdownMenu.tsx
@@ -1,14 +1,32 @@
 'use client';
 import React, { useState, useEffect, useRef, ComponentType, SVGProps } from 'react';
+import clsx from 'clsx';
 
 interface DropdownProps {
-  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  icon?: ComponentType<SVGProps<SVGSVGElement>>;
+  sideIcon?: ComponentType<SVGProps<SVGSVGElement>>;
+  text?: string;
   dropdownList: string[];
+  dropdownAlign?: 'center' | 'right';
   onItemClick: (item: string) => void;
   className?: string;
+  iconClassName?: string;
+  buttonClassName?: string;
+  dropdownListClassName?: string;
 }
 
-const DropdownMenu = ({ icon: Icon, dropdownList, onItemClick, className: iconButtonClasses }: DropdownProps) => {
+const DropdownMenu = ({
+  icon: Icon,
+  sideIcon: SideIcon,
+  text,
+  dropdownList,
+  dropdownAlign = 'right',
+  onItemClick,
+  className,
+  iconClassName,
+  buttonClassName,
+  dropdownListClassName,
+}: DropdownProps) => {
   const [isDropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const iconButtonRef = useRef<HTMLButtonElement>(null);
@@ -46,28 +64,36 @@ const DropdownMenu = ({ icon: Icon, dropdownList, onItemClick, className: iconBu
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
+  const dropdownClassNames = clsx(
+    'z-10 absolute mt-2 bg-white rounded-xl text-slate-700',
+    dropdownAlign === 'right' ? 'right-0 shadow-[4px_4px_10px_-2px_rgba(0,0,0,0.05)]' : 'w-full shadow-lg left-0'
+  );
+
+  const dropdownMenuListClassNames = clsx(
+    'w-full flex justify-center items-center text-center',
+    'px-4 pt-2 pb-[6px] hover:bg-gray-100 cursor-pointer first:rounded-t-xl last:rounded-b-xl',
+    dropdownListClassName
+  );
+
   return (
-    <div className='flex-col justify-center items-center relative inline-block'>
+    <div className={`flex-col justify-center items-center relative inline-block text-nowrap ${className}`}>
       <button
         ref={iconButtonRef}
         onClick={toggleDropdown}
         onMouseOut={handleMouseOut}
-        className='rounded focus:outline-none flex justify-center items-center'
-        aria-label='더보기 메뉴 열기'
+        className={`rounded focus:outline-none flex w-full justify-between items-center ${buttonClassName}`}
       >
-        <Icon width={24} height={24} className={iconButtonClasses} />
+        {Icon ? <Icon width={24} height={24} className={iconClassName} /> : <div>{text}</div>}
+        {SideIcon && <SideIcon width={24} height={24} className={iconClassName} />}
       </button>
 
       {isDropdownOpen && (
-        <div
-          ref={dropdownRef}
-          className='z-10 absolute right-0 mt-2 w-auto bg-white rounded-xl shadow-[4px_4px_10px_-2px_rgba(0,0,0,0.05)] items-center'
-        >
-          <ul className='flex flex-col text-nowrap text-sm sm:text-lg lg:text-lg text-slate-700 justify-center items-center text-center'>
+        <div ref={dropdownRef} className={dropdownClassNames}>
+          <ul className='flex flex-col text-nowrap text-sm sm:text-lg lg:text-lg justify-center items-center text-center'>
             {dropdownList.map((listItem, idx) => (
               <li
                 key={idx}
-                className='flex justify-center items-center text-center px-4 pt-2 pb-[6px] hover:bg-gray-100 cursor-pointer first:rounded-t-xl last:rounded-b-xl'
+                className={dropdownMenuListClassNames}
                 onClick={() => {
                   onItemClick(listItem);
                   closeDropdown();

--- a/components/common/DropdownMenu.tsx
+++ b/components/common/DropdownMenu.tsx
@@ -13,6 +13,7 @@ interface DropdownProps {
   iconClassName?: string;
   buttonClassName?: string;
   dropdownListClassName?: string;
+  dropdownItemClassName?: string;
 }
 
 const DropdownMenu = ({
@@ -26,6 +27,7 @@ const DropdownMenu = ({
   iconClassName,
   buttonClassName,
   dropdownListClassName,
+  dropdownItemClassName,
 }: DropdownProps) => {
   const [isDropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -65,14 +67,19 @@ const DropdownMenu = ({
   }, []);
 
   const dropdownClassNames = clsx(
-    'z-10 absolute mt-2 bg-white rounded-xl text-slate-700',
+    'z-10 absolute mt-2 bg-white rounded-xl text-slate-700 max-h-64 sm:max-h-32 lg:max-h-32 overflow-y-auto',
     dropdownAlign === 'right' ? 'right-0 shadow-[4px_4px_10px_-2px_rgba(0,0,0,0.05)]' : 'w-full shadow-lg left-0'
   );
 
   const dropdownMenuListClassNames = clsx(
-    'w-full flex justify-center items-center text-center',
-    'px-4 pt-2 pb-[6px] hover:bg-gray-100 cursor-pointer first:rounded-t-xl last:rounded-b-xl',
+    'flex flex-col text-nowrap text-sm sm:text-lg lg:text-lg justify-center items-center text-center',
     dropdownListClassName
+  );
+
+  const dropdownMenuItemClassNames = clsx(
+    'w-full flex max-h-[100px] overflow-y-auto',
+    'px-4 pt-2 pb-[6px] hover:bg-gray-100 cursor-pointer first:rounded-t-xl last:rounded-b-xl',
+    dropdownItemClassName
   );
 
   return (
@@ -90,11 +97,11 @@ const DropdownMenu = ({
 
       {isDropdownOpen && (
         <div ref={dropdownRef} className={dropdownClassNames}>
-          <ul className='flex flex-col text-nowrap text-sm sm:text-lg lg:text-lg justify-center items-center text-center'>
+          <ul className={dropdownMenuListClassNames}>
             {dropdownList.map((listItem, idx) => (
               <li
                 key={idx}
-                className={dropdownMenuListClassNames}
+                className={dropdownMenuItemClassNames}
                 onClick={() => {
                   onItemClick(listItem);
                   closeDropdown();

--- a/components/common/DropdownMenu.tsx
+++ b/components/common/DropdownMenu.tsx
@@ -79,6 +79,7 @@ const DropdownMenu = ({
     <div className={`flex-col justify-center items-center relative inline-block text-nowrap ${className}`}>
       <button
         ref={iconButtonRef}
+        type='button'
         onClick={toggleDropdown}
         onMouseOut={handleMouseOut}
         className={`rounded focus:outline-none flex w-full justify-between items-center ${buttonClassName}`}

--- a/components/modal/todoModal/GoalSelector.tsx
+++ b/components/modal/todoModal/GoalSelector.tsx
@@ -6,12 +6,14 @@ import IconArrowDown from '@/public/icons/IconArrowDown';
 import clsx from 'clsx';
 
 interface GoalSelectorProps {
+  label: string;
+  placeholder: string;
   goals: GoalInTodo[] | undefined;
   onSelect: (goalId: number | null) => void;
   selectedGoalId: number | null;
 }
 
-const GoalSelector = ({ goals, onSelect, selectedGoalId }: GoalSelectorProps) => {
+const GoalSelector = ({ label, placeholder, goals, onSelect, selectedGoalId }: GoalSelectorProps) => {
   const [selectedGoal, setSelectedGoal] = useState<GoalInTodo | null>(null);
 
   useEffect(() => {
@@ -39,7 +41,7 @@ const GoalSelector = ({ goals, onSelect, selectedGoalId }: GoalSelectorProps) =>
   };
 
   const isPlaceholder = !selectedGoal;
-  const dropdownText = selectedGoal ? selectedGoal.title : '목표를 선택해주세요';
+  const dropdownText = selectedGoal ? selectedGoal.title : placeholder;
   const goalClass = clsx(
     'w-full px-6 py-3 rounded-xl',
     'focus:outline-none focus:ring-1 focus:ring-blue-500',
@@ -49,15 +51,16 @@ const GoalSelector = ({ goals, onSelect, selectedGoalId }: GoalSelectorProps) =>
   );
 
   return (
-    <div className='w-full justify-center items-center text-center'>
+    <div className='w-full justify-center pt-6'>
+      {label && <label className={'block text-sm font-semibold text-slate-800 mb-3 sm:text-base'}>{label}</label>}
       <DropdownMenu
         text={dropdownText}
         sideIcon={IconArrowDown}
-        dropdownList={['목표를 선택해주세요', ...(goals ? goals.map((goal) => goal.title) : [])]}
+        dropdownList={[placeholder, ...(goals ? goals.map((goal) => goal.title) : [])]}
         dropdownAlign='center'
         onItemClick={handleDropdownClick}
         className={goalClass}
-        dropdownListClassName='bg-gray-50 hover:bg-gray-200'
+        dropdownItemClassName='bg-gray-50 hover:bg-gray-200'
       />
       <input type='hidden' value={selectedGoal ? selectedGoal.id : ''} />
     </div>

--- a/components/modal/todoModal/GoalSelector.tsx
+++ b/components/modal/todoModal/GoalSelector.tsx
@@ -1,0 +1,67 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import { GoalInTodo } from '@/lib/types/todos';
+import DropdownMenu from '@/components/common/DropdownMenu';
+import IconArrowDown from '@/public/icons/IconArrowDown';
+import clsx from 'clsx';
+
+interface GoalSelectorProps {
+  goals: GoalInTodo[] | undefined;
+  onSelect: (goalId: number | null) => void;
+  selectedGoalId: number | null;
+}
+
+const GoalSelector = ({ goals, onSelect, selectedGoalId }: GoalSelectorProps) => {
+  const [selectedGoal, setSelectedGoal] = useState<GoalInTodo | null>(null);
+
+  useEffect(() => {
+    if (selectedGoalId !== null) {
+      const goal = goals?.find((g) => g.id === selectedGoalId);
+      setSelectedGoal(goal || null);
+    } else {
+      setSelectedGoal(null);
+    }
+  }, [selectedGoalId, goals]);
+
+  const handleItemClick = (goal: GoalInTodo) => {
+    setSelectedGoal(goal);
+    onSelect(goal.id);
+  };
+
+  const handleDropdownClick = (item: string) => {
+    const goal = goals?.find((g) => g.title === item);
+    if (goal) {
+      handleItemClick(goal);
+    } else {
+      setSelectedGoal(null);
+      onSelect(null);
+    }
+  };
+
+  const isPlaceholder = !selectedGoal;
+  const dropdownText = selectedGoal ? selectedGoal.title : '목표를 선택해주세요';
+  const goalClass = clsx(
+    'w-full px-6 py-3 rounded-xl',
+    'focus:outline-none focus:ring-1 focus:ring-blue-500',
+    'bg-gray-50',
+    'text-sm sm:text-base',
+    isPlaceholder ? 'text-slate-400' : 'text-slate-800'
+  );
+
+  return (
+    <div className='w-full justify-center items-center text-center'>
+      <DropdownMenu
+        text={dropdownText}
+        sideIcon={IconArrowDown}
+        dropdownList={['목표를 선택해주세요', ...(goals ? goals.map((goal) => goal.title) : [])]}
+        dropdownAlign='center'
+        onItemClick={handleDropdownClick}
+        className={goalClass}
+        dropdownListClassName='bg-gray-50 hover:bg-gray-200'
+      />
+      <input type='hidden' value={selectedGoal ? selectedGoal.id : ''} />
+    </div>
+  );
+};
+
+export default GoalSelector;

--- a/components/modal/todoModal/TodoAddModal.tsx
+++ b/components/modal/todoModal/TodoAddModal.tsx
@@ -73,6 +73,8 @@ const Content = () => {
           error={errors.fileUrl?.message}
         />
         <GoalSelector
+          label='목표'
+          placeholder='목표를 선택해주세요'
           goals={goals}
           onSelect={(goalId) => setValue('goalId', goalId)}
           selectedGoalId={watch('goalId')}

--- a/components/modal/todoModal/TodoAddModal.tsx
+++ b/components/modal/todoModal/TodoAddModal.tsx
@@ -9,6 +9,7 @@ import Button from '@/components/common/ButtonSlid';
 import { useAddTodoMutation } from '@/lib/hooks/useAddTodoMutation';
 import { TodoAddFormData, todoAddSchema } from '@/lib/schemas/todosSchemas';
 import cleanedFormData from '@/lib/utils/cleanedFormData';
+import GoalSelector from './GoalSelector';
 
 interface TodoAddModalProps {
   children?: React.ReactNode;
@@ -35,7 +36,6 @@ const Content = () => {
 
   const onSubmit = (data: TodoAddFormData) => {
     const cleanedData = cleanedFormData(data);
-
     addTodo.mutate({ updates: cleanedData });
     handleClose();
   };
@@ -45,7 +45,7 @@ const Content = () => {
 
   return (
     <ModalContent className='sm:w-[520px] sm:h-[676px] w-full h-full p-4 sm:p-6 flex flex-col'>
-      <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-4'>
+      <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-4 w-full'>
         <div className='flex gap-2 flex-col'>
           <div className='flex justify-between items-center'>
             <h1 className='text-lg font-bold'>할 일 생성</h1>
@@ -70,12 +70,10 @@ const Content = () => {
           watch={watch}
           error={errors.fileUrl?.message}
         />
-        <InputSlid
-          label='목표'
-          type='select'
-          placeholder='정해진 목표가 없습니다'
-          {...register('goalId')}
-          options={goals && goals.map((goal) => ({ value: goal.id, label: goal.title }))}
+        <GoalSelector
+          goals={goals}
+          onSelect={(goalId) => setValue('goalId', goalId)}
+          selectedGoalId={watch('goalId')}
         />
         <div className='mt-10'>
           <Button type='submit' className='w-full'>

--- a/components/modal/todoModal/TodoAddModal.tsx
+++ b/components/modal/todoModal/TodoAddModal.tsx
@@ -24,6 +24,7 @@ const Content = () => {
     formState: { errors },
     setValue,
     watch,
+    reset,
   } = useForm<TodoAddFormData>({
     resolver: zodResolver(todoAddSchema),
     defaultValues: {
@@ -37,6 +38,7 @@ const Content = () => {
   const onSubmit = (data: TodoAddFormData) => {
     const cleanedData = cleanedFormData(data);
     addTodo.mutate({ updates: cleanedData });
+    reset();
     handleClose();
   };
 

--- a/components/modal/todoModal/TodoEditModal.tsx
+++ b/components/modal/todoModal/TodoEditModal.tsx
@@ -11,6 +11,7 @@ import Button from '@/components/common/ButtonSlid';
 import { TodoEditFormData, todoEditSchema } from '@/lib/schemas/todosSchemas';
 import { useUpdateTodoMutation } from '@/lib/hooks/useUpdateTodoMutation';
 import cleanedFormData from '@/lib/utils/cleanedFormData';
+import GoalSelector from './GoalSelector';
 
 interface TodoEditModalProps {
   data: Todo;
@@ -76,13 +77,19 @@ const Content = ({ data }: { data: Todo }) => {
           watch={watch}
           error={errors.fileUrl?.message}
         />
-        <InputSlid
+        {/* <InputSlid
           label='목표'
           type='select'
           placeholder='정해진 목표가 없습니다'
           {...register('goalId')}
           options={goals && goals.map((goal) => ({ value: goal.id, label: goal.title }))}
+        /> */}
+        <GoalSelector
+          goals={goals}
+          onSelect={(goalId) => setValue('goalId', goalId)}
+          selectedGoalId={watch('goalId')}
         />
+
         <div className='mt-10'>
           <Button type='submit' className='w-full'>
             확인

--- a/components/modal/todoModal/TodoEditModal.tsx
+++ b/components/modal/todoModal/TodoEditModal.tsx
@@ -78,6 +78,8 @@ const Content = ({ data }: { data: Todo }) => {
           error={errors.fileUrl?.message}
         />
         <GoalSelector
+          label='목표'
+          placeholder='목표를 선택해주세요'
           goals={goals}
           onSelect={(goalId) => setValue('goalId', goalId)}
           selectedGoalId={watch('goalId')}

--- a/components/modal/todoModal/TodoEditModal.tsx
+++ b/components/modal/todoModal/TodoEditModal.tsx
@@ -77,13 +77,6 @@ const Content = ({ data }: { data: Todo }) => {
           watch={watch}
           error={errors.fileUrl?.message}
         />
-        {/* <InputSlid
-          label='목표'
-          type='select'
-          placeholder='정해진 목표가 없습니다'
-          {...register('goalId')}
-          options={goals && goals.map((goal) => ({ value: goal.id, label: goal.title }))}
-        /> */}
         <GoalSelector
           goals={goals}
           onSelect={(goalId) => setValue('goalId', goalId)}


### PR DESCRIPTION
## ✅ 작업 내용
할 일 모달에서 목표선택 input select를 공통컴포넌트 DropdownMenu로 변경했습니다.

- DropdownMenu 커스텀 가능하게 수정
- 할 일 추가 모달에서 목표 선택 DropdownMenu로 변경하기
- 할 일 수정 모달에서 목표 선택 DropdownMenu로 변경하기
- 새 할일 제목 입력 후 목표 클릭시 폼 전송되는 오류 수정
- 새 할일 폼 제출 후 남아있던 이전 기록 초기화
- DropdownMenu 최대 높이 설정해 모달 밖으로 빠져나가지 않도록 수정


## 📸 스크린샷 / GIF / Link
before
![image](https://github.com/user-attachments/assets/50d87b80-eeb2-40ed-844f-e87761940870)

after
![image](https://github.com/user-attachments/assets/2e0df497-8e37-4291-b21a-e3d2be3eefca)

![image](https://github.com/user-attachments/assets/ae7bc948-7cec-495c-8317-0b1091585d69)

