### PR TITLE
[ 노트 ] 노트 생성수정 페이지 할일, 목표명 상태 참조 변경

### DIFF
--- a/app/(nav)/todos/[todoId]/_view/NoteFormContent.tsx
+++ b/app/(nav)/todos/[todoId]/_view/NoteFormContent.tsx
@@ -3,11 +3,10 @@
 import { ModalClose, ModalContent, ModalProvider, ModalTrigger } from '@/components/common/Modal';
 import TiptapEditor from '@/components/TiptapEditor';
 import useNoteMutation from '@/lib/hooks/useNoteMutation';
-import useTodosQuery from '@/lib/hooks/useTodosQuery';
 import IconClose from '@/public/icons/IconClose';
 import IconEmbed from '@/public/icons/IconEmbed';
 import IconFlag from '@/public/icons/IconFlag';
-import { useParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 import {
   ChangeEventHandler,
   FormEventHandler,
@@ -54,11 +53,12 @@ type NoteFormContentProps = {
 
 const NoteFormContent = memo(
   ({ linkUrl = '', initTitle = '', method = 'POST', noteId, onSaveLinkUrl, onOpenEmbed }: NoteFormContentProps) => {
+    const searchParams = useSearchParams();
+    const todoTitle = searchParams.get('todo');
+    const goalTitle = searchParams.get('goal');
     const { editor } = useCurrentEditor();
     const [linkUrlValue, setLinkUrlValue] = useState(linkUrl);
     const { todoId } = useParams();
-    const { data } = useTodosQuery(todoId as string);
-    const todo = data?.todos.find((todo) => todo.id === Number(todoId));
     const { mutate } = useNoteMutation(todoId as string);
     const [title, setTitle] = useState(initTitle);
     const [savedToast, setSavedToast] = useState(false);
@@ -170,11 +170,11 @@ const NoteFormContent = memo(
           <div className='flex justify-center items-center rounded-md bg-slate-800 w-6 h-6'>
             <IconFlag />
           </div>
-          <p className='font-medium text-base text-slate-800'>{todo?.goal.title}</p>
+          <p className='font-medium text-base text-slate-800'>{goalTitle}</p>
         </div>
         <div className='flex w-full gap-2 mb-6'>
           <p className='rounded-md bg-slate-100 p-1 text-slate-700 text-xs'>To do</p>
-          <p className='text-sm font-normal text-slate-700'>{todo?.title}</p>
+          <p className='text-sm font-normal text-slate-700'>{todoTitle}</p>
         </div>
 
         {openSavedToast && (

--- a/components/common/todoItem/TodoIcon.tsx
+++ b/components/common/todoItem/TodoIcon.tsx
@@ -9,6 +9,7 @@ import { Todo } from '@/lib/types/todos';
 import { useRef } from 'react';
 import TodoEditModal from '@/components/modal/todoModal/TodoEditModal';
 import { SheetTrigger } from '../Sheet';
+import { useRouter } from 'next/navigation';
 
 interface TodoIconProps {
   data: Todo;
@@ -17,6 +18,7 @@ interface TodoIconProps {
 const TodoIcon: React.FC<TodoIconProps> = ({ data }) => {
   const modalRef = useRef<HTMLButtonElement>(null);
   const deleteTodo = useDeleteTodoMutation();
+  const router = useRouter();
 
   const handleDelete = () => {
     // 삭제할지 모달을 띄워주면 좋겠음
@@ -48,6 +50,11 @@ const TodoIcon: React.FC<TodoIconProps> = ({ data }) => {
     if (!linkUrl) return;
     window.open(linkUrl, '_blank', 'noopener,noreferrer');
   };
+
+  const handleCreateNote = () => {
+    router.push(`/todos/${data.id}/create?todo=${data.title}&goal=${data.goal?.title}`);
+  };
+
   return (
     <>
       <div className='flex items-center gap-x-2'>
@@ -68,7 +75,9 @@ const TodoIcon: React.FC<TodoIconProps> = ({ data }) => {
             <IconNoteView className='hover:stroke-slate-100 hover:fill-slate-200 cursor-pointer' />
           </SheetTrigger>
         )}
-        <IconNoteWrite className='hover:stroke-slate-100 hover:fill-slate-200 cursor-pointer' />
+        <button onClick={handleCreateNote}>
+          <IconNoteWrite className='hover:stroke-slate-100 hover:fill-slate-200 cursor-pointer' />
+        </button>
         <div className='flex justify-center items-center'>
           <DropdownMenu
             icon={IconKebabWithCircle}

--- a/components/common/todoItem/index.tsx
+++ b/components/common/todoItem/index.tsx
@@ -8,6 +8,7 @@ import TodoIcon from './TodoIcon';
 import GoalTitle from './GoalTitle';
 import { SheetClose, SheetContent, SheetProvider, SheetTrigger } from '../Sheet';
 import NoteDetail from '@/components/notes/NoteDetail';
+import { usePathname } from 'next/navigation';
 
 interface TodoItemProps {
   data: Todo;
@@ -15,6 +16,8 @@ interface TodoItemProps {
 }
 
 const TodoItem: React.FC<TodoItemProps> = ({ data, viewGoal }) => {
+  const pathname = usePathname();
+
   return (
     <SheetProvider>
       <div className='text-sm group'>
@@ -33,14 +36,17 @@ const TodoItem: React.FC<TodoItemProps> = ({ data, viewGoal }) => {
         </div>
         {viewGoal && data.goal?.id && <GoalTitle goal={data.goal} />}
       </div>
-      <SheetContent className='relative'>
-        <div className='overflow-auto h-full'>
-          <div className='flex justify-end mb-6'>
-            <SheetClose />
-          </div>
-          <NoteDetail id={data.noteId} goalTitle={data.goal ? data.goal.title : ''} todoTitle={data.title} />
-        </div>
-      </SheetContent>
+      {pathname.includes('/notes/') ||
+        (pathname.includes('/todos') && (
+          <SheetContent className='relative'>
+            <div className='overflow-auto h-full'>
+              <div className='flex justify-end mb-6'>
+                <SheetClose />
+              </div>
+              <NoteDetail id={data.noteId ?? 0} goalTitle={data.goal ? data.goal.title : ''} todoTitle={data.title} />
+            </div>
+          </SheetContent>
+        ))}
     </SheetProvider>
   );
 };

--- a/components/notes/NoteDetail.tsx
+++ b/components/notes/NoteDetail.tsx
@@ -3,6 +3,10 @@ import IconEmbed from '@/public/icons/IconEmbed';
 import IconFlag from '@/public/icons/IconFlag';
 import { useState } from 'react';
 import TiptapEditorProvider from '../TiptapEditorProvider';
+import DropdownMenu from '../common/DropdownMenu';
+import { IconKebabWithCircle } from '@/public/icons/IconKebabWithCircle';
+import { useDeleteNoteMutation } from '@/lib/hooks/useDeleteNoteMutation';
+import { useRouter } from 'next/navigation';
 
 type NoteDetailProps = {
   id: number;
@@ -12,6 +16,28 @@ type NoteDetailProps = {
 
 const NoteDetail = ({ id, goalTitle, todoTitle }: NoteDetailProps) => {
   const { data: note, isLoading } = useNoteQuery(id);
+
+  const createdAt = new Date(note?.createdAt ?? 0);
+  const year = createdAt.getFullYear();
+  const month = createdAt.getMonth() + 1;
+  const date = createdAt.getDate();
+  const deleteNote = useDeleteNoteMutation();
+  const router = useRouter();
+
+  const handleDelete = () => {
+    // 삭제할지 모달을 띄워주면 좋겠음
+    deleteNote.mutate({ noteId: id });
+  };
+
+  const handleDropdaownMenuClick = (item: string) => {
+    if (item === '수정하기') {
+      // 수정하기페이지로 이동
+      router.push(`/todos/${note?.todo.id}/note/${note?.id}?todo=${note?.todo.title}&goal=${note?.goal.title}`);
+    } else if (item === '삭제하기') {
+      handleDelete();
+    }
+  };
+
   const [isEmbedOpen, setIsEmbedOpen] = useState(false);
 
   const handleToggleEmbed = () => setIsEmbedOpen(!isEmbedOpen);
@@ -34,10 +60,20 @@ const NoteDetail = ({ id, goalTitle, todoTitle }: NoteDetailProps) => {
             <IconFlag />
           </div>
           <p className='font-medium text-base text-slate-800'>{goalTitle}</p>
+          <div className='grow flex justify-end w-10'>
+            <DropdownMenu
+              icon={IconKebabWithCircle}
+              dropdownList={['수정하기', '삭제하기']}
+              onItemClick={handleDropdaownMenuClick}
+            />
+          </div>
         </div>
-        <div className='flex w-full gap-2 mb-6'>
+        <div className='flex items-center w-full gap-2 mb-6'>
           <p className='rounded-md bg-slate-100 p-1 text-slate-700 text-xs'>To do</p>
           <p className='text-sm font-normal text-slate-700'>{todoTitle}</p>
+          <p className='grow text-right text-xs text-slate-500'>
+            {year}. {String(month).padStart(2, '0')}. {date}
+          </p>
         </div>
 
         <hr />
@@ -58,7 +94,7 @@ const NoteDetail = ({ id, goalTitle, todoTitle }: NoteDetailProps) => {
           )}
           <div className='lg:relative'>
             <div>
-              <TiptapEditorProvider content={note?.content} editorOptions={{ editable: false }}></TiptapEditorProvider>
+              <TiptapEditorProvider content={note?.content} editorOptions={{ editable: false }} />
             </div>
           </div>
         </div>

--- a/components/notes/NoteItem.tsx
+++ b/components/notes/NoteItem.tsx
@@ -6,6 +6,7 @@ import { useDeleteNoteMutation } from '@/lib/hooks/useDeleteNoteMutation';
 import { MouseEventHandler, useRef } from 'react';
 import NoteDetail from './NoteDetail';
 import { SheetClose, SheetContent, SheetProvider, SheetTrigger } from '../common/Sheet';
+import { useRouter } from 'next/navigation';
 
 interface NoteItemProps {
   note: Note;
@@ -13,6 +14,7 @@ interface NoteItemProps {
 
 const NoteItem: React.FC<NoteItemProps> = ({ note }) => {
   const deleteNote = useDeleteNoteMutation();
+  const router = useRouter();
 
   const handleDelete = () => {
     // 삭제할지 모달을 띄워주면 좋겠음
@@ -22,6 +24,7 @@ const NoteItem: React.FC<NoteItemProps> = ({ note }) => {
   const handleDropdaownMenuClick = (item: string) => {
     if (item === '수정하기') {
       // 수정하기페이지로 이동
+      router.push(`/todos/${note.todo.id}/note/${note.id}?todo=${note.todo.title}&goal=${note.goal.title}`);
     } else if (item === '삭제하기') {
       handleDelete();
     }


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->

<!-- ex) [Home] 대시보드에서 ~~ 구현 -->

## ✅ 작업 내용
노트 생성/수정 페이지의 할일명, 목표명을
기존 서버 요청하여 참조하던 상태를
URL 쿼리스트링에서 참조하도록 변경했습니다. 

추가로 노트사이드시트 날짜 UI 삽입,
수정삭제 케밥 삽입,
모든할일, 노트모아보기 페이지에서만 사이드시트 열리도록 처리했습니다. (`usePathname`)

## 📸 스크린샷 / GIF / Link
![image](https://github.com/user-attachments/assets/f8b90a3b-9f84-4ea2-8db9-edd0fc35c57e)


## 📌 이슈 사항
Closes #125 

## ✍ 궁금한 것
