### PR TITLE
[ 공통컴포넌트 ] ModalProvider 프롭스 추가

### DIFF
--- a/components/common/Modal.tsx
+++ b/components/common/Modal.tsx
@@ -21,17 +21,30 @@ const ModalContext = createContext<
   { isOpen: boolean; handleOpen: () => void; handleClose: () => void; beforeClose?: () => void } | undefined
 >(undefined);
 
-const ModalProvider = ({ beforeClose, children }: PropsWithChildren<{ beforeClose?: () => void }>) => {
+const ModalProvider = ({
+  isOpen: initIsOpen,
+  onChangeIsOpen,
+  beforeClose,
+  children,
+}: PropsWithChildren<{ isOpen?: boolean; onChangeIsOpen?: (isOpen: boolean) => void; beforeClose?: () => void }>) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleOpen = () => setIsOpen(true);
+  const handleOpen = () => {
+    setIsOpen(true);
+    onChangeIsOpen?.(true);
+  };
 
   const handleClose = () => {
     beforeClose?.();
+    onChangeIsOpen?.(false);
     setIsOpen(false);
   };
 
-  return <ModalContext.Provider value={{ isOpen, handleOpen, handleClose }}>{children}</ModalContext.Provider>;
+  return (
+    <ModalContext.Provider value={{ isOpen: initIsOpen ?? isOpen, handleOpen, handleClose }}>
+      {children}
+    </ModalContext.Provider>
+  );
 };
 
 const useModalContext = () => {


### PR DESCRIPTION

<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->

<!-- ex) [Home] 대시보드에서 ~~ 구현 -->

## ✅ 작업 내용
- 부모컴포넌트의 상태로 모달 열림을 관리할 수 있도록 ModalProvider에 해당 상태를 프롭으로 전달할 수 있도록 수정했습니다.
- 기존 방식으로 작성된 모달도 작동할 수 있도록 isOpen, onChangeIsOpen 프롭은 옵셔널 프롭입니다.

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항
Closes #131 

## ✍ 궁금한 것
