### PR TITLE
[ 노트 ] 임시저장글 불러오기 오류 수정

### DIFF
--- a/app/(nav)/todos/[todoId]/_view/NoteForm.tsx
+++ b/app/(nav)/todos/[todoId]/_view/NoteForm.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import IconModalClose from '@/public/icons/IconModalClose';
-import NoteFormContent from './NoteFormContent';
+import NoteFormContent, { SavedNote } from './NoteFormContent';
 import TiptapEditorProvider from '@/components/TiptapEditorProvider';
+import { useParams } from 'next/navigation';
 
 type NoteFormProps = {
   title?: string;
@@ -13,6 +14,21 @@ type NoteFormProps = {
   noteId?: string;
 };
 
+type NoteFormContentProps = {
+  linkUrl?: string;
+  initTitle?: string;
+  method: 'POST' | 'PATCH';
+  noteId?: string;
+  openSavedToast: boolean;
+  savedNote: SavedNote;
+  savedToast: boolean;
+  onSaveLinkUrl: (value: string) => void;
+  onOpenEmbed: () => void;
+  onOpenSaved: () => void;
+  onChangeSavedToast: (status: boolean) => void;
+  onChangeOpenSavedToast: (status: boolean) => void;
+};
+
 const NoteForm = ({
   title: initTitle = '',
   content: initContent = '',
@@ -20,13 +36,78 @@ const NoteForm = ({
   method = 'POST',
   noteId,
 }: NoteFormProps) => {
+  const { todoId } = useParams();
   const [linkUrl, setLinkUrl] = useState(initLinkUrl);
   const [isEmbedOpen, setIsEmbedOpen] = useState(false);
+  const [content, setContent] = useState(initContent);
+  const [title, setTitle] = useState(initTitle);
+  const [openSavedToast, setOpenSavedToast] = useState(false);
+  const [savedToast, setSavedToast] = useState(false);
+
+  const handleChangeOpenSavedToast = (status: boolean) => setOpenSavedToast(status);
+  const handleChangeSavedToast = (status: boolean) => setSavedToast(status);
+  const handleChangeContent = (newContent: string) => setContent(newContent);
 
   const handleSaveLinkUrl = useCallback((linkUrlValue: string) => setLinkUrl(linkUrlValue), []);
 
   const handleOpenEmbed = useCallback(() => setIsEmbedOpen(true), []);
   const handleCloseEmbed = () => setIsEmbedOpen(false);
+
+  const savedNote = useMemo<SavedNote>(() => {
+    if (!globalThis.window) return;
+    const item = window.localStorage.getItem('savedNote' + todoId);
+    return item && JSON.parse(item);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [todoId, savedToast]);
+
+  const handleOpenSaved = useCallback(() => {
+    if (!savedNote) return;
+    setTitle(savedNote.title.length ? savedNote.title : '제목없음');
+    setLinkUrl(savedNote.linkUrl);
+    handleChangeContent(savedNote.content);
+    setOpenSavedToast(false);
+  }, [savedNote]);
+
+  const TiptapProviderOnContentChange = useCallback(
+    ({
+      linkUrl,
+      initTitle,
+      method,
+      noteId,
+      savedNote,
+      savedToast,
+      openSavedToast,
+      onSaveLinkUrl,
+      onOpenEmbed,
+      onOpenSaved,
+      onChangeSavedToast,
+      onChangeOpenSavedToast,
+    }: NoteFormContentProps) => {
+      return (
+        <TiptapEditorProvider
+          className='resize-none w-full h-full focus-visible:outline-none text-slate-700 whitespace-break-spaces '
+          content={content}
+          slotBefore={
+            <NoteFormContent
+              linkUrl={linkUrl}
+              initTitle={initTitle}
+              method={method}
+              noteId={noteId}
+              savedNote={savedNote}
+              savedToast={savedToast}
+              openSavedToast={openSavedToast}
+              onSaveLinkUrl={onSaveLinkUrl}
+              onOpenEmbed={onOpenEmbed}
+              onOpenSaved={onOpenSaved}
+              onChangeSavedToast={onChangeSavedToast}
+              onChangeOpenSavedToast={onChangeOpenSavedToast}
+            />
+          }
+        />
+      );
+    },
+    [content]
+  );
 
   return (
     <>
@@ -42,19 +123,19 @@ const NoteForm = ({
           </div>
         </section>
       )}
-      <TiptapEditorProvider
-        className='resize-none w-full h-full focus-visible:outline-none text-slate-700 whitespace-break-spaces '
-        content={initContent}
-        slotBefore={
-          <NoteFormContent
-            linkUrl={linkUrl}
-            initTitle={initTitle}
-            method={method}
-            noteId={noteId}
-            onSaveLinkUrl={handleSaveLinkUrl}
-            onOpenEmbed={handleOpenEmbed}
-          />
-        }
+      <TiptapProviderOnContentChange
+        linkUrl={linkUrl}
+        initTitle={title}
+        method={method}
+        noteId={noteId}
+        savedNote={savedNote}
+        savedToast={savedToast}
+        openSavedToast={openSavedToast}
+        onSaveLinkUrl={handleSaveLinkUrl}
+        onOpenEmbed={handleOpenEmbed}
+        onOpenSaved={handleOpenSaved}
+        onChangeSavedToast={handleChangeSavedToast}
+        onChangeOpenSavedToast={handleChangeOpenSavedToast}
       />
     </>
   );


### PR DESCRIPTION
## ✅ 작업 내용
- 임시저장된 노트 content를 업데이트할 함수가 없었음.
- content는 팁탭 에디터로 관리되는데 Editor 인스턴스의 프로퍼티나 메서드로 content를 업데이트 할 수 없음.
- 결과: 임시저장 content가 불러와질 때마다 EditorProvider를 새로 렌더하도록 기존 프로바이더 컴포넌트를 useCallback으로 반환, 의존성 배열에 content 추가. 프로바이더 하위에서 관리되던 상태(토스트, 임시저장기능 등)를 상위컴포넌트로 이동.

<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->

<!-- ex) [Home] 대시보드에서 ~~ 구현 -->


## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항
Closes #133 

## ✍ 궁금한 것
