### PR TITLE
[ 노트 ] 노트 수정/생성 후 리디렉션 추가

### DIFF
--- a/app/(nav)/todos/[todoId]/_view/NoteFormContent.tsx
+++ b/app/(nav)/todos/[todoId]/_view/NoteFormContent.tsx
@@ -6,7 +6,7 @@ import useNoteMutation from '@/lib/hooks/useNoteMutation';
 import IconClose from '@/public/icons/IconClose';
 import IconEmbed from '@/public/icons/IconEmbed';
 import IconFlag from '@/public/icons/IconFlag';
-import { useParams, useSearchParams } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import {
   ChangeEventHandler,
   FormEventHandler,
@@ -34,6 +34,7 @@ import IconAddLink from '@/public/icons/IconAddLink';
 import InputSlid from '@/components/common/InputSlid';
 import Button from '@/components/common/ButtonSlid';
 import ModalSavedNote from './ModalSavedNote';
+import { afterNoteMutation } from '@/app/actions';
 
 export type SavedNote = {
   title: string;
@@ -71,6 +72,7 @@ const NoteFormContent = memo(
     onChangeSavedToast,
     onChangeOpenSavedToast,
   }: NoteFormContentProps) => {
+    const router = useRouter();
     const searchParams = useSearchParams();
     const todoTitle = searchParams.get('todo');
     const goalTitle = searchParams.get('goal');
@@ -134,10 +136,18 @@ const NoteFormContent = memo(
         delete note.linkUrl;
       }
 
-      mutate({
-        noteId,
-        options: { method, body: JSON.stringify(note) },
-      });
+      mutate(
+        {
+          noteId,
+          options: { method, body: JSON.stringify(note) },
+        },
+        {
+          onSuccess: () => {
+            afterNoteMutation(Array.isArray(todoId) ? todoId[0] : todoId, noteId ?? '0');
+            router.push('/dashboard');
+          },
+        }
+      );
     };
 
     const handleBold = () => editor?.chain().focus().toggleBold().run();

--- a/app/(nav)/todos/[todoId]/_view/NoteFormContent.tsx
+++ b/app/(nav)/todos/[todoId]/_view/NoteFormContent.tsx
@@ -144,7 +144,7 @@ const NoteFormContent = memo(
         {
           onSuccess: () => {
             afterNoteMutation(Array.isArray(todoId) ? todoId[0] : todoId, noteId ?? '0');
-            router.push('/dashboard');
+            router.back();
           },
         }
       );

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,0 +1,7 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+export async function afterNoteMutation(todoId: string, noteId: string) {
+  revalidatePath(`/todos/${todoId}/note/${noteId}`, 'page');
+}


### PR DESCRIPTION

<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->

<!-- ex) [Home] 대시보드에서 ~~ 구현 -->

## ✅ 작업 내용
- 수정 후 수정페이지로 다시 이동하면 이전 데이터가 캐시로 남기 때문에 서버액션을 통한 revalidatePath 호출, 해당 페이지 캐시 초기화

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항
Closes #137 

## ✍ 궁금한 것
