### PR TITLE
[ 대시보드 ] 전체 달성률 표시 

### DIFF
--- a/components/dashboard/Progress.tsx
+++ b/components/dashboard/Progress.tsx
@@ -2,6 +2,7 @@ import { ImageProgress } from '@/public/images/ImageProgress';
 import { ImageProgressMobile } from '@/public/images/ImageProgressMobile';
 import { ImageProgressTablet } from '@/public/images/ImageProgressTablet';
 import { IconProgress } from '@/public/icons/IconProgress';
+import ProgressText from './ProgressText';
 
 const Progress = () => {
   return (
@@ -14,13 +15,7 @@ const Progress = () => {
         <div className='w-10 h-10 bg-slate-900 rounded-[15px] grid place-content-center'>
           <IconProgress />
         </div>
-        <div className='flex-col mt-4'>
-          <p className='text-white text-lg font-semibold text-nowrap'>내 진행 상황</p>
-          <span className='flex mt-1 items-center gap-1 text-nowrap'>
-            <p className='text-white text-3xl font-bold'>74</p>
-            <p className='text-white text-base font-semibold'>%</p>
-          </span>
-        </div>
+        <ProgressText />
       </div>
       <div className='absolute right-0 bottom-0'>
         <ImageProgressMobile className='block sm:hidden lg:hidden' />

--- a/components/dashboard/ProgressText.tsx
+++ b/components/dashboard/ProgressText.tsx
@@ -1,0 +1,17 @@
+import useTodoProgressQuery from '@/lib/hooks/useTodoProgressQuery';
+
+const ProgressText = () => {
+  const { data } = useTodoProgressQuery();
+  const percentage = data?.progress || 0;
+  return (
+    <div className='flex-col mt-4'>
+      <p className='text-white text-lg font-semibold text-nowrap'>내 진행 상황</p>
+      <span className='flex mt-1 items-center gap-1 text-nowrap'>
+        <p className='text-white text-3xl font-bold'>{percentage}</p>
+        <p className='text-white text-base font-semibold'>%</p>
+      </span>
+    </div>
+  );
+};
+
+export default ProgressText;

--- a/lib/hooks/useTodoProgressQuery.ts
+++ b/lib/hooks/useTodoProgressQuery.ts
@@ -1,10 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import baseFetch from '../api/baseFetch';
+import { GetTodosProgressResponse } from '../types/todos';
 
-const useTodoProgressQuery = (goalId: number) => {
-  return useQuery({
+const useTodoProgressQuery = (goalId?: number) => {
+  return useQuery<GetTodosProgressResponse>({
     queryKey: ['GoalProgress', goalId],
-    queryFn: () => baseFetch(`/4-4-dev/todos/progress?goalId=${goalId}`),
+    queryFn: () => baseFetch(`/4-4-dev/todos/progress?goalId=${goalId ?? ''}`),
   });
 };
 

--- a/lib/types/todos.ts
+++ b/lib/types/todos.ts
@@ -22,3 +22,7 @@ export interface GetTodosResponse {
   totalCount: number;
   nextCursor?: number;
 }
+
+export interface GetTodosProgressResponse {
+  progress: number;
+}


### PR DESCRIPTION
close #142 

## ✅ 작업 내용
- dashboard 페이지에서 전체 달성률을 볼 수 있습니다
- 전체 달성률을 가져오기 위해 [useTodoProgressQuery.ts](https://github.com/FESI-4-4/slid-todo/compare/feature/142?expand=1#diff-bf11eefbb2556edbc63fd119065f0562276afae1fd98b52bd54081582ff2042d)를 약간 수정하였습니다.





https://github.com/user-attachments/assets/272d8e2d-0cda-4064-b3c5-61f5596eee59

