### PR TITLE
[ 노트 ] 노트 수정 후 사이드시트, `/notes/[goalId]` 페이지 데이터 업데이트 수정

### DIFF
--- a/app/(nav)/todos/[todoId]/_view/NoteFormContent.tsx
+++ b/app/(nav)/todos/[todoId]/_view/NoteFormContent.tsx
@@ -35,6 +35,8 @@ import InputSlid from '@/components/common/InputSlid';
 import Button from '@/components/common/ButtonSlid';
 import ModalSavedNote from './ModalSavedNote';
 import { afterNoteMutation } from '@/app/actions';
+import { revalidatePath } from 'next/cache';
+import { useQueryClient } from '@tanstack/react-query';
 
 export type SavedNote = {
   title: string;
@@ -72,6 +74,7 @@ const NoteFormContent = memo(
     onChangeSavedToast,
     onChangeOpenSavedToast,
   }: NoteFormContentProps) => {
+    const queryClient = useQueryClient();
     const router = useRouter();
     const searchParams = useSearchParams();
     const todoTitle = searchParams.get('todo');
@@ -144,6 +147,7 @@ const NoteFormContent = memo(
         {
           onSuccess: () => {
             afterNoteMutation(Array.isArray(todoId) ? todoId[0] : todoId, noteId ?? '0');
+            queryClient.invalidateQueries({ queryKey: ['notes'] });
             router.back();
           },
         }

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -3,5 +3,5 @@
 import { revalidatePath } from 'next/cache';
 
 export async function afterNoteMutation(todoId: string, noteId: string) {
-  revalidatePath(`/todos/${todoId}/note/${noteId}`, 'page');
+  revalidatePath(`/todos/${todoId}/note/${noteId}`);
 }

--- a/components/notes/NoteDetail.tsx
+++ b/components/notes/NoteDetail.tsx
@@ -1,7 +1,7 @@
 import useNoteQuery from '@/lib/hooks/useNoteQuery';
 import IconEmbed from '@/public/icons/IconEmbed';
 import IconFlag from '@/public/icons/IconFlag';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import TiptapEditorProvider from '../TiptapEditorProvider';
 import DropdownMenu from '../common/DropdownMenu';
 import { IconKebabWithCircle } from '@/public/icons/IconKebabWithCircle';
@@ -41,6 +41,10 @@ const NoteDetail = ({ id, goalTitle, todoTitle }: NoteDetailProps) => {
   const [isEmbedOpen, setIsEmbedOpen] = useState(false);
 
   const handleToggleEmbed = () => setIsEmbedOpen(!isEmbedOpen);
+
+  const TiptapProviderOnContentChange = useCallback(() => {
+    return <TiptapEditorProvider content={note?.content} editorOptions={{ editable: false }} />;
+  }, [note?.content]);
 
   if (isLoading) return;
 
@@ -94,7 +98,7 @@ const NoteDetail = ({ id, goalTitle, todoTitle }: NoteDetailProps) => {
           )}
           <div className='lg:relative'>
             <div>
-              <TiptapEditorProvider content={note?.content} editorOptions={{ editable: false }} />
+              <TiptapProviderOnContentChange />
             </div>
           </div>
         </div>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->

<!-- ex) [Home] 대시보드에서 ~~ 구현 -->

## ✅ 작업 내용
노트 수정 후 사이드시트, `/notes/[goalId]` 페이지 데이터 업데이트 수정
- 노트 카드, 노트 사이드시트 제목은 탠스택 쿼리 캐시를 invalidate
- 노트 사이드시트 content는 팁탭 프로바이더를 새로 생성하도록 `useCallback(()=>{}, [note?.content])` 사용

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항
Closes #147 

## ✍ 궁금한 것
