### PR TITLE
[ Drawer ] 모바일 용 Drawer 스타일링

### DIFF
--- a/components/common/todoItem/TodoIcon.tsx
+++ b/components/common/todoItem/TodoIcon.tsx
@@ -71,6 +71,7 @@ const TodoIcon: React.FC<TodoIconProps> = ({ data }) => {
 
   const handleSheet = () => {
     if (isMobile()) return;
+    setIsSheetOpen(true);
   };
 
   return (

--- a/components/common/todoItem/TodoTitle.tsx
+++ b/components/common/todoItem/TodoTitle.tsx
@@ -1,6 +1,8 @@
+import TodoContentsDrawer from '@/components/drawer/TodoContentsDrawer';
 import { MOBILE_BREAKPOINT } from '@/constants';
 import { Todo } from '@/lib/types/todo';
 import clsx from 'clsx';
+import { useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 interface TodoTitleProps {
@@ -8,21 +10,26 @@ interface TodoTitleProps {
 }
 
 const TodoTitle: React.FC<TodoTitleProps> = ({ data }) => {
+  const [isOpen, setIsOpen] = useState(false);
   const handleTitleClick = () => {
     if (window.innerWidth >= MOBILE_BREAKPOINT) {
       //모바일이 아닐 때
     } else {
       // 모바일 일 때
+      setIsOpen(true);
     }
   };
 
   return (
-    <div
-      onClick={handleTitleClick}
-      className={twMerge(clsx('truncate hover:text-link cursor-pointer', data.done && 'line-through'))}
-    >
-      {data.title}
-    </div>
+    <>
+      <div
+        onClick={handleTitleClick}
+        className={twMerge(clsx('truncate hover:text-link cursor-pointer', data.done && 'line-through'))}
+      >
+        {data.title}
+      </div>
+      <TodoContentsDrawer isopen={isOpen} onChangeIsOpen={setIsOpen} data={data} />
+    </>
   );
 };
 

--- a/components/drawer/TodoContentsDrawer.tsx
+++ b/components/drawer/TodoContentsDrawer.tsx
@@ -1,0 +1,64 @@
+import { Todo } from '@/lib/types/todo';
+import { SheetContent, SheetProvider } from '../common/Sheet';
+import IconFile from '@/public/icons/IconFile';
+import IconLink from '@/public/icons/IconLink';
+import IconNoteView from '@/public/icons/IconNoteView';
+import IconNoteWrite from '@/public/icons/IconNoteWrite';
+import Button from '../common/ButtonSlid';
+
+interface TodoContentsDrawerProps {
+  isopen: boolean;
+  onChangeIsOpen: (isOpen: boolean) => void;
+  data: Todo;
+}
+
+const TodoContentsDrawer: React.FC<TodoContentsDrawerProps> = ({ isopen, onChangeIsOpen, data }) => {
+  return (
+    <SheetProvider isOpen={isopen} onChangeIsOpen={onChangeIsOpen}>
+      <SheetContent position='bottom' className='w-full h-auto'>
+        <div className='flex flex-col space-y-6'>
+          <h2 className='text-center'>{data.title}</h2>
+          <div className='flex justify-around'>
+            <Button>수정하기</Button>
+            <Button>삭제하기</Button>
+          </div>
+          <div className='space-y-4'>
+            {data.fileUrl && (
+              <div className='flex space-x-2 cursor-pointer hover:underline'>
+                <IconFile />
+                <p>파일 다운로드</p>
+              </div>
+            )}
+            {data.linkUrl && (
+              <div className='flex space-x-2 cursor-pointer hover:underline'>
+                <IconLink />
+                <p>링크 들어가기</p>
+              </div>
+            )}
+            {data.noteId && (
+              <div className='flex space-x-2 cursor-pointer hover:underline'>
+                <IconNoteView />
+                <p>노트 보기</p>
+              </div>
+            )}
+            {data.noteId && (
+              <div className='flex space-x-2 cursor-pointer hover:underline'>
+                <IconNoteWrite />
+                <p>노트 수정하기</p>
+              </div>
+            )}
+            {/**노트 아이디가 없을 때 추가히기 **/}
+            {!data.noteId && (
+              <div className='flex space-x-2 cursor-pointer hover:underline'>
+                <IconNoteWrite />
+                <p>노트 추가하기</p>
+              </div>
+            )}
+          </div>
+        </div>
+      </SheetContent>
+    </SheetProvider>
+  );
+};
+
+export default TodoContentsDrawer;


### PR DESCRIPTION
close #169 

## ✅ 작업 내용
- todoitem에 사용할 Drawer 기본 디자인했습니다
- sheet에 상태값 연결 할 수 있어서 깔끔하게 title에 연결했습니다!

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/e43db720-b34a-4c85-bf88-e4217acc944f



## 📌 이슈 사항
sheet가 나올때 애니메이션을 (천천히 아래에서 나오는 효과) 주고 싶었는데 아마 커스터마이징할 수 있는 className의 더 외각에 있는 녀석이라 현재는 못넣는거 같습니다!
- Drawer에도 이제 추가하기 누르면 모달이 열리고 노트보기 누르면 노트시트가 등장해야하는데 이를 용이하게 하려면 리팩토링이 좀 필요해보입니다!


