### PR TITLE
[ 모달 ] 각종 확인모달

### DIFF
--- a/components/SignUpForm.tsx
+++ b/components/SignUpForm.tsx
@@ -11,7 +11,7 @@ import IconCheck from '@/public/icons/IconCheck';
 import SignupSuccessModal from './modal/SignupSuccessModal';
 
 const SignUpForm: React.FC = () => {
-  const modalRef = useRef<HTMLButtonElement>(null);
+  const [isSusccessModalOpen, setIsSuccessModalOpen] = useState<boolean>(false);
   const [isEmailAvailable, setIsEmailAvailable] = useState<boolean>(false);
 
   const {
@@ -32,8 +32,7 @@ const SignUpForm: React.FC = () => {
       setIsEmailAvailable(false);
       const response = await signUp(fetchData);
       console.log(response);
-
-      modalRef.current?.click();
+      setIsSuccessModalOpen(true);
     } catch (error) {
       if (error instanceof Error) {
         if (error.message.includes('이메일')) {
@@ -172,7 +171,7 @@ const SignUpForm: React.FC = () => {
           회원가입하기
         </Button>
       </form>
-      <SignupSuccessModal ref={modalRef} />
+      <SignupSuccessModal isOpen={isSusccessModalOpen} onChangeIsOpen={setIsSuccessModalOpen} />
     </>
   );
 };

--- a/components/common/todoItem/TodoIcon.tsx
+++ b/components/common/todoItem/TodoIcon.tsx
@@ -11,6 +11,7 @@ import TodoEditModal from '@/components/modal/todoModal/TodoEditModal';
 import { useRouter } from 'next/navigation';
 import { MOBILE_BREAKPOINT } from '@/constants';
 import NoteViewSheet from '@/components/sheet/NoteViewSheet';
+import DeleteConfirmationModal from '@/components/modal/DeleteConfirmationModal';
 
 interface TodoIconProps {
   data: Todo;
@@ -22,12 +23,12 @@ const TodoIcon: React.FC<TodoIconProps> = ({ data }) => {
   const router = useRouter();
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const handleSheetOpen = (isOpen: boolean) => setIsSheetOpen(isOpen);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const isMobile = () => window.innerWidth < MOBILE_BREAKPOINT;
 
   const handleDelete = () => {
     if (isMobile()) return;
-    // 삭제할지 모달을 띄워주면 좋겠음
     deleteTodo.mutate({ todoId: data.id });
   };
 
@@ -36,7 +37,7 @@ const TodoIcon: React.FC<TodoIconProps> = ({ data }) => {
     if (item === '수정하기') {
       onChangeIsOpen(true);
     } else if (item === '삭제하기') {
-      handleDelete();
+      setIsDeleteModalOpen(true);
     }
   };
 
@@ -112,6 +113,12 @@ const TodoIcon: React.FC<TodoIconProps> = ({ data }) => {
         noteId={data.noteId}
         goal={data.goal}
         todoTitle={data.title}
+      />
+      <DeleteConfirmationModal
+        isOpen={isDeleteModalOpen}
+        onChangeIsOpen={setIsDeleteModalOpen}
+        itemType='todo'
+        onDelete={handleDelete}
       />
     </>
   );

--- a/components/modal/DeleteConfirmationModal.tsx
+++ b/components/modal/DeleteConfirmationModal.tsx
@@ -1,0 +1,46 @@
+import { DELETE_ITEM_TEXTS } from '@/constants';
+import Button from '../common/ButtonSlid';
+import { ModalContent, ModalProvider } from '../common/Modal';
+
+export type DeleteItemType = 'goal' | 'note' | 'todo';
+
+interface DeleteConfirmationModalProps {
+  isOpen: boolean;
+  onChangeIsOpen: (value: boolean) => void;
+  onDelete: () => void;
+  itemType: DeleteItemType;
+  customTitle?: string;
+  customMessage?: string;
+}
+
+const DeleteConfirmationModal = ({
+  isOpen,
+  onChangeIsOpen,
+  onDelete,
+  itemType,
+  customTitle,
+  customMessage,
+}: DeleteConfirmationModalProps) => {
+  const { title, message } = DELETE_ITEM_TEXTS[itemType];
+
+  return (
+    <ModalProvider isOpen={isOpen} onChangeIsOpen={onChangeIsOpen}>
+      <ModalContent closeOnClickOverlay={false} className='sm:w-[450px]'>
+        <div className='flex flex-col items-center gap-4'>
+          <h1 className='text-lg font-bold'>{customTitle ?? title}</h1>
+          <p className='text-center whitespace-pre-line'>{customMessage ?? message}</p>
+          <div className='flex gap-4'>
+            <Button className='w-[120px] py-3' variant='outlined' onClick={() => onChangeIsOpen(false)}>
+              취소
+            </Button>
+            <Button className='w-[120px] py-3' onClick={onDelete}>
+              삭제
+            </Button>
+          </div>
+        </div>
+      </ModalContent>
+    </ModalProvider>
+  );
+};
+
+export default DeleteConfirmationModal;

--- a/components/modal/SignupSuccessModal.tsx
+++ b/components/modal/SignupSuccessModal.tsx
@@ -1,20 +1,19 @@
-import { forwardRef } from 'react';
-import { ModalContent, ModalProvider, ModalTrigger } from '../common/Modal';
+import { ModalContent, ModalProvider } from '../common/Modal';
 import Button from '../common/ButtonSlid';
 import { useRouter } from 'next/navigation';
 
 interface SignupSuccessModalProps {
-  children?: React.ReactNode;
+  isOpen: boolean;
+  onChangeIsOpen: (isOpen: boolean) => void;
 }
 
-const SignupSuccessModal = forwardRef<HTMLButtonElement, SignupSuccessModalProps>(({ children }, ref) => {
+const SignupSuccessModal: React.FC<SignupSuccessModalProps> = ({ isOpen, onChangeIsOpen }) => {
   const router = useRouter();
   const handleRedirect = () => {
     router.push('/login');
   };
   return (
-    <ModalProvider>
-      <ModalTrigger ref={ref}>{children}</ModalTrigger>
+    <ModalProvider isOpen={isOpen} onChangeIsOpen={onChangeIsOpen}>
       <ModalContent closeOnClickOverlay={false}>
         <div className='flex flex-col items-center gap-4'>
           <h1 className='text-lg font-bold'>회원가입 성공</h1>
@@ -25,8 +24,6 @@ const SignupSuccessModal = forwardRef<HTMLButtonElement, SignupSuccessModalProps
       </ModalContent>
     </ModalProvider>
   );
-});
-
-SignupSuccessModal.displayName = 'SignupSuccessModal';
+};
 
 export default SignupSuccessModal;

--- a/components/notes/NoteDetail.tsx
+++ b/components/notes/NoteDetail.tsx
@@ -9,6 +9,7 @@ import { useDeleteNoteMutation } from '@/lib/hooks/useDeleteNoteMutation';
 import { useRouter } from 'next/navigation';
 import { useSheetContext } from '../common/Sheet';
 import { useQueryClient } from '@tanstack/react-query';
+import DeleteConfirmationModal from '../modal/DeleteConfirmationModal';
 
 type NoteDetailProps = {
   id: number;
@@ -20,6 +21,7 @@ const NoteDetail = ({ id, goalTitle, todoTitle }: NoteDetailProps) => {
   const { data: note, isLoading } = useNoteQuery(id);
   const { handleClose } = useSheetContext();
   const queryClient = useQueryClient();
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const createdAt = new Date(note?.createdAt ?? 0);
   const year = createdAt.getFullYear();
@@ -29,7 +31,6 @@ const NoteDetail = ({ id, goalTitle, todoTitle }: NoteDetailProps) => {
   const router = useRouter();
 
   const handleDelete = () => {
-    // 삭제할지 모달을 띄워주면 좋겠음
     deleteNote.mutate(
       { noteId: id },
       {
@@ -46,7 +47,7 @@ const NoteDetail = ({ id, goalTitle, todoTitle }: NoteDetailProps) => {
       // 수정하기페이지로 이동
       router.push(`/todos/${note?.todo.id}/note/${note?.id}?todo=${note?.todo.title}&goal=${note?.goal.title}`);
     } else if (item === '삭제하기') {
-      handleDelete();
+      setIsDeleteModalOpen(true);
     }
   };
 
@@ -115,6 +116,12 @@ const NoteDetail = ({ id, goalTitle, todoTitle }: NoteDetailProps) => {
           </div>
         </div>
       </section>
+      <DeleteConfirmationModal
+        isOpen={isDeleteModalOpen}
+        onChangeIsOpen={setIsDeleteModalOpen}
+        onDelete={handleDelete}
+        itemType='note'
+      />
     </>
   );
 };

--- a/components/notes/NoteItem.tsx
+++ b/components/notes/NoteItem.tsx
@@ -6,6 +6,7 @@ import { useDeleteNoteMutation } from '@/lib/hooks/useDeleteNoteMutation';
 import { MouseEventHandler, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import NoteViewSheet from '../sheet/NoteViewSheet';
+import DeleteConfirmationModal from '../modal/DeleteConfirmationModal';
 
 interface NoteItemProps {
   note: Note;
@@ -15,8 +16,8 @@ const NoteItem: React.FC<NoteItemProps> = ({ note }) => {
   const deleteNote = useDeleteNoteMutation();
   const router = useRouter();
   const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const handleDelete = () => {
-    // 삭제할지 모달을 띄워주면 좋겠음
     deleteNote.mutate({ noteId: note.id });
   };
 
@@ -25,7 +26,7 @@ const NoteItem: React.FC<NoteItemProps> = ({ note }) => {
       // 수정하기페이지로 이동
       router.push(`/todos/${note.todo.id}/note/${note.id}?todo=${note.todo.title}&goal=${note.goal.title}`);
     } else if (item === '삭제하기') {
-      handleDelete();
+      setIsDeleteModalOpen(true);
     }
   };
 
@@ -67,6 +68,12 @@ const NoteItem: React.FC<NoteItemProps> = ({ note }) => {
         noteId={note.id}
         goal={note.goal}
         todoTitle={note.todo.title}
+      />
+      <DeleteConfirmationModal
+        isOpen={isDeleteModalOpen}
+        onChangeIsOpen={setIsDeleteModalOpen}
+        onDelete={handleDelete}
+        itemType='note'
       />
     </>
   );

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,3 +1,18 @@
 export const API_BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
 export const MOBILE_BREAKPOINT = 640;
+
+export const DELETE_ITEM_TEXTS = {
+  goal: {
+    title: '목표 삭제',
+    message: '목표를 삭제하시겠습니까?\n삭제된 목표는 복구할 수 없습니다.',
+  },
+  note: {
+    title: '노트 삭제',
+    message: '노트를 삭제하시겠습니까?\n삭제된 노트는 복구할 수 없습니다.',
+  },
+  todo: {
+    title: '할 일 삭제',
+    message: '할 일을 삭제하시겠습니까?\n삭제된 할 일은 복구할 수 없습니다.',
+  },
+};


### PR DESCRIPTION
close #177 

## ✅ 작업 내용
- 계정생성후 뜨는 모달 코드를 부모에게 상태를 받는 방식으로 바꿨습니다.
- 삭제 확인 모달을 만들었습니다.
- 삭제 확인 모달을 할일, 노트의 삭제하기 (드롭다운)버튼에 연결하였습니다.

## 📸 스크린샷 / GIF / Link

https://github.com/user-attachments/assets/85e13865-5fef-4aed-8578-30bdd909610d


## 📌 이슈 사항
- 목표 페이지에 목표 삭제 쪽은 작업하시고 계시는거 같아서 그냥 두었습니다
- 나중에 목표삭제 하기에 모달 연결하실 때 components/notes/NoteItem.tsx 참고하시면 될거 같습니다!
- todo를 추가하는 form 나갈때 나오는 모달은 만들지 않았습니다. '작성된 모든 내용이 삭제됩니다.'라는 메시지에 맞지 않게 기존 작성된 내용이 저장되어 있습니다. -> 오히려 더 편리함
- 임시저장불러오기 모달은 이미 만드셔서 안만들었습니다
