### PR TITLE
[ 노트 ] 노트 삭제 후 query invalidation 예외 처리 및 삭제

### DIFF
--- a/components/notes/NoteDetail.tsx
+++ b/components/notes/NoteDetail.tsx
@@ -36,6 +36,7 @@ const NoteDetail = ({ id, goalTitle, todoTitle }: NoteDetailProps) => {
       {
         onSuccess: () => {
           queryClient.invalidateQueries({ queryKey: ['todos'] });
+          queryClient.removeQueries({ queryKey: ['notes', id] });
           handleClose();
         },
       }

--- a/lib/hooks/useDeleteNoteMutation.ts
+++ b/lib/hooks/useDeleteNoteMutation.ts
@@ -15,8 +15,10 @@ export const useDeleteNoteMutation = () => {
       });
     },
 
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['notes'] });
+    onSettled: (_data, _error, variables) => {
+      queryClient.invalidateQueries({
+        predicate: (query) => query.queryKey[0] === 'notes' && query.queryKey[1] !== variables.noteId,
+      });
     },
   });
 };


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->

<!-- ex) [Home] 대시보드에서 ~~ 구현 -->

## ✅ 작업 내용
노트 삭제 후 `['notes']` 키를 가진 쿼리를 전부 invalidate 하지 않고 predicate으로 삭제된 노트 쿼리는 예외 처리하도록 했습니다. 
삭제된 노트의 쿼리는 삭제됩니다. (`['notes', noteId]`) 

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항
Closes #159 

## ✍ 궁금한 것
