### PR TITLE
[ 목표 상세 ] 디자인 오류 수정

### DIFF
--- a/app/(nav)/dashboard/page.tsx
+++ b/app/(nav)/dashboard/page.tsx
@@ -7,7 +7,7 @@ import RecentTodo from '@/components/dashboard/RecentTodo';
 
 export default function DashboardPage() {
   return (
-    <PageContainer className={'max-w-[1200px]'}>
+    <PageContainer className={'max-w-[1200px] gap-4'}>
       <div className='hidden sm:block lg:block'>
         <PageHeader title='대시보드' />
       </div>

--- a/app/(nav)/goals/[goalId]/page.tsx
+++ b/app/(nav)/goals/[goalId]/page.tsx
@@ -8,7 +8,7 @@ import Link from 'next/link';
 
 export default function GoalDetailPage({ params }: { params: { goalId: string } }) {
   return (
-    <PageContainer className={'max-w-[1200px] space-y-6'}>
+    <PageContainer className={'max-w-[1200px] flex flex-col gap-4'}>
       <div className='hidden sm:block lg:block'>
         <PageHeader title='목표' />
       </div>
@@ -17,7 +17,9 @@ export default function GoalDetailPage({ params }: { params: { goalId: string } 
       </article>
       <div className='bg-blue-100 rounded-xl'>
         <Link href={`/notes/${params.goalId}`} className='flex px-6 py-4 gap-2 items-center'>
-          <IconNoteAll />
+          <div className='flex-shrink-0'>
+            <IconNoteAll />
+          </div>
           <span className='text-lg font-bold text-slate-800'>노트 모아보기</span>
           <div className='ml-auto'>
             <IconArrowRight />

--- a/app/(nav)/goals/[goalId]/page.tsx
+++ b/app/(nav)/goals/[goalId]/page.tsx
@@ -24,7 +24,9 @@ export default function GoalDetailPage({ params }: { params: { goalId: string } 
           </div>
         </Link>
       </div>
-      <TodoItemsGoal goalId={+params.goalId} />
+      <div className='flex flex-col'>
+        <TodoItemsGoal goalId={+params.goalId} />
+      </div>
     </PageContainer>
   );
 }

--- a/components/common/GoalTitleWithProgress.tsx
+++ b/components/common/GoalTitleWithProgress.tsx
@@ -13,7 +13,7 @@ const GoalTitleWithProgress = ({ goalId }: { goalId: number }) => {
   return (
     <div className='w-full bg-white rounded-xl px-6 py-4'>
       <div className='w-full flex items-center gap-2'>
-        <div className='w-10 h-10 bg-slate-900 rounded-[15px] grid place-content-center'>
+        <div className='w-10 h-10 flex-shrink-0 bg-slate-900 rounded-[15px] grid place-content-center'>
           <IconFlag />
         </div>
         <span className='text-lg font-semibold'>{goal?.title}</span>

--- a/components/dashboard/GoalTodo.tsx
+++ b/components/dashboard/GoalTodo.tsx
@@ -20,7 +20,7 @@ const GoalTodo = () => {
     <section className='flex mt-6 w-full'>
       <div className='flex-col px-6 py-4 w-full h-auto min-h-[768px] bg-white rounded-xl border border-slate-100'>
         <div className='flex items-center gap-2'>
-          <div className='w-10 h-10 bg-orange-500 rounded-[15px] grid place-content-center'>
+          <div className='w-10 h-10 flex-shrink-0 bg-orange-500 rounded-[15px] grid place-content-center'>
             <IconDashboardFlag />
           </div>
           <p className='text-slate-800 text-lg font-semibold'>목표 별 할 일</p>

--- a/components/dashboard/Progress.tsx
+++ b/components/dashboard/Progress.tsx
@@ -6,11 +6,7 @@ import ProgressText from './ProgressText';
 
 const Progress = () => {
   return (
-    <section
-      className=' relative flex flex-1 justify-between w-[343px] h-[250px] 
-    sm:w-[306px] sm:h-[250px]
-    lg:h-[250px] bg-blue-500 rounded-xl'
-    >
+    <section className='relative flex flex-1 min-w-0 min-h-[250px] justify-between bg-blue-500 rounded-xl'>
       <div className='flex-col px-6 pt-4'>
         <div className='w-10 h-10 bg-slate-900 rounded-[15px] grid place-content-center'>
           <IconProgress />

--- a/components/dashboard/RecentTodo.tsx
+++ b/components/dashboard/RecentTodo.tsx
@@ -9,14 +9,12 @@ const RecentTodo = () => {
   const recentTodos = data?.pages[0];
   return (
     <section
-      className='flex flex-1 flex-col bg-white rounded-xl border border-slate-100 gap-4
-      w-[343px] h-[250px] px-4 pb-6 pt-4
-      sm:w-[306px] sm:h-[250px] sm:px-6 sm:pb-6 sm:pt-4
-      lg:h-[250px]
+      className='flex flex-1 flex-col min-w-0 min-h-[250px] bg-white rounded-xl border border-slate-100 gap-4
+      px-4 pb-6 pt-4 sm:px-6 sm:pb-6 sm:pt-4
     '
     >
       <div className='flex items-center w-full gap-2'>
-        <div className='w-10 h-10 bg-blue-500 rounded-[15px] grid place-content-center'>
+        <div className='w-10 h-10 flex-shrink-0 bg-blue-500 rounded-[15px] grid place-content-center'>
           <IconTodoRecently />
         </div>
         <p className='text-slate-800 text-lg font-semibold text-nowrap'>최근 등록한 할 일</p>

--- a/components/goals/TodoItemsGoal.tsx
+++ b/components/goals/TodoItemsGoal.tsx
@@ -40,12 +40,11 @@ const TodoItemsGoal = ({ goalId }: { goalId: number }) => {
     });
   }, [views, queries]);
 
-  const baseContainerClasses =
-    'w-full h-auto flex flex-col min-h-[228px] max-h-[228px] sm:max-h-[228px] lg:max-h-[456px] p-4 gap-3';
+  const baseContainerClasses = 'h-auto flex flex-col flex-1 p-4 gap-3';
 
   const contentClass = (isEmpty: boolean) =>
     clsx(
-      'w-full flex overflow-y-auto min-h-[200px]',
+      'w-full flex overflow-y-auto min-h-[200px] max-h-[228px] lg:max-h-[456px]',
       isEmpty ? 'h-full flex-col sm:flex-col lg:flex-row justify-center items-center' : 'h-auto flex-col gap-2'
     );
 


### PR DESCRIPTION
## ✅ 작업 내용
- 모바일, 태블릿에서 리스트가 카드를 빠져나오는 오류를 수정했습니다.
- 모바일 환경에서 페이지 제목이 숨김 처리 될 경우 남아있던 여백을 제거했습니다.
- 화면을 줄여도 아이콘이 줄어들지 않도록 수정했습니다.
- 목표 상세 페이지의 여백을 조정했습니다.
- 대시보드 컨텐츠들의 길이를 조정했습니다.

## 📸 스크린샷 / GIF / Link
![image](https://github.com/user-attachments/assets/82f8b600-a7bd-4759-a723-41972f33769b)

close #178 