### PR TITLE
[ 노트 ] 링크모달 엔터 저장

### DIFF
--- a/app/(nav)/todos/[todoId]/_view/AddLinkModal.tsx
+++ b/app/(nav)/todos/[todoId]/_view/AddLinkModal.tsx
@@ -1,0 +1,58 @@
+import Button from '@/components/common/ButtonSlid';
+import InputSlid from '@/components/common/InputSlid';
+import { ModalClose, ModalContent, ModalProvider, ModalTrigger } from '@/components/common/Modal';
+import IconAddLink from '@/public/icons/IconAddLink';
+import { ChangeEventHandler, FormEventHandler, useState } from 'react';
+
+type AddLinkModalProps = {
+  linkUrl: string;
+  onSave: (linkUrl: string) => void;
+};
+
+const ModalInput = ({ linkUrl }: { linkUrl: string }) => {
+  const [linkUrlValue, setLinkUrlValue] = useState(linkUrl);
+  const handleChangeLinkUrlValue: ChangeEventHandler<HTMLInputElement | HTMLSelectElement> = (e) =>
+    setLinkUrlValue(e.target.value);
+
+  return (
+    <InputSlid
+      name='linkUrl'
+      label='링크'
+      type='text'
+      placeholder='영상이나 글, 파일의 링크를 넣어주세요'
+      className='mb-10'
+      value={linkUrlValue}
+      onChange={handleChangeLinkUrlValue}
+    />
+  );
+};
+
+const AddLinkModal = ({ linkUrl, onSave }: AddLinkModalProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleSaveLinkUrl: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+    const formData = new FormData(e.target as HTMLFormElement);
+    onSave((formData.get('linkUrl') as string) ?? '');
+    setIsOpen(false);
+  };
+
+  return (
+    <ModalProvider isOpen={isOpen} onChangeIsOpen={setIsOpen}>
+      <ModalTrigger type='button'>
+        <IconAddLink className='cursor-pointer hover:bg-slate-100' />
+      </ModalTrigger>
+      <ModalContent className='w-full max-w-[520px] flex flex-col'>
+        <div className='flex justify-between mb-6'>
+          <h1 className='text-lg font-bold'>링크 업로드</h1>
+          <ModalClose />
+        </div>
+        <form onSubmit={handleSaveLinkUrl}>
+          <ModalInput linkUrl={linkUrl} />
+          <Button className='w-full'>확인</Button>
+        </form>
+      </ModalContent>
+    </ModalProvider>
+  );
+};
+export default AddLinkModal;

--- a/app/(nav)/todos/[todoId]/_view/NoteFormContent.tsx
+++ b/app/(nav)/todos/[todoId]/_view/NoteFormContent.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ModalClose, ModalContent, ModalProvider, ModalTrigger } from '@/components/common/Modal';
 import TiptapEditor from '@/components/TiptapEditor';
 import useNoteMutation from '@/lib/hooks/useNoteMutation';
 import IconClose from '@/public/icons/IconClose';
@@ -31,13 +30,12 @@ import IconTextItalics from '@/public/icons/IconTextItalics';
 import IconTextNumberPoint from '@/public/icons/IconTextNumberPoint';
 import IconTextUnderline from '@/public/icons/IconTextUnderline';
 import IconTextHighlight from '@/public/icons/IconTextHighlight';
-import IconAddLink from '@/public/icons/IconAddLink';
-import InputSlid from '@/components/common/InputSlid';
 import Button from '@/components/common/ButtonSlid';
-import ModalSavedNote from './ModalSavedNote';
+import OpenSavedNoteModal from './OpenSavedNoteModal';
 import { afterNoteMutation } from '@/app/actions';
 import { useQueryClient } from '@tanstack/react-query';
 import SecondsTimer from './SecondsTimer';
+import AddLinkModal from './AddLinkModal';
 
 export type SavedNote = {
   title: string;
@@ -82,7 +80,6 @@ const NoteFormContent = memo(
     const todoTitle = searchParams.get('todo');
     const goalTitle = searchParams.get('goal');
     const { editor } = useCurrentEditor();
-    const [linkUrlValue, setLinkUrlValue] = useState(linkUrl);
     const [title, setTitle] = useState(initTitle);
     const titleRef = useRef<HTMLInputElement>(null);
     const { mutate } = useNoteMutation(todoId as string);
@@ -93,9 +90,7 @@ const NoteFormContent = memo(
       return note.savedAt;
     }, [savedNote, todoId]);
 
-    const handleChangeLinkUrlValue: ChangeEventHandler<HTMLInputElement | HTMLSelectElement> = (e) =>
-      setLinkUrlValue(e.target.value);
-    const handleSaveLinkUrl = () => onSaveLinkUrl(linkUrlValue);
+    const handleSaveLinkUrl = (linkUrlValue: string) => onSaveLinkUrl(linkUrlValue);
     const handleChangeTitle: ChangeEventHandler<HTMLInputElement> = (e) => {
       setTitle(e.target.value.length > 30 ? e.target.value.slice(0, 30) : e.target.value);
     };
@@ -208,7 +203,7 @@ const NoteFormContent = memo(
               <IconClose circleFill='fill-blue-500' className='cursor-pointer' />
             </button>
             <p className='font-semibold text-sm grow'>임시 저장된 노트가 있어요. 저장된 노트를 불러오시겠어요?</p>
-            <ModalSavedNote onOpenSaved={onOpenSaved} savedNote={savedNote} />
+            <OpenSavedNoteModal onOpenSaved={onOpenSaved} savedNote={savedNote} />
           </div>
         )}
         <hr />
@@ -285,30 +280,7 @@ const NoteFormContent = memo(
               </label>
             </div>
             <div className='grow flex justify-end'>
-              <ModalProvider>
-                <ModalTrigger type='button'>
-                  <IconAddLink className='cursor-pointer hover:bg-slate-100' />
-                </ModalTrigger>
-                <ModalContent className='w-full max-w-[520px] flex flex-col'>
-                  <div className='flex justify-between mb-6'>
-                    <h1 className='text-lg font-bold'>링크 업로드</h1>
-                    <ModalClose />
-                  </div>
-                  <InputSlid
-                    label='링크'
-                    type='text'
-                    placeholder='영상이나 글, 파일의 링크를 넣어주세요'
-                    className='mb-10'
-                    value={linkUrlValue}
-                    onChange={handleChangeLinkUrlValue}
-                  />
-                  <ModalClose asChild>
-                    <Button className='w-full' onClick={handleSaveLinkUrl}>
-                      확인
-                    </Button>
-                  </ModalClose>
-                </ModalContent>
-              </ModalProvider>
+              <AddLinkModal linkUrl={linkUrl} onSave={handleSaveLinkUrl} />
             </div>
           </div>
           {savedToast && (

--- a/app/(nav)/todos/[todoId]/_view/OpenSavedNoteModal.tsx
+++ b/app/(nav)/todos/[todoId]/_view/OpenSavedNoteModal.tsx
@@ -10,7 +10,7 @@ type ModalSavedNoteProps = {
   onOpenSaved: () => void;
 };
 
-const ModalSavedNote = memo(({ savedNote, onOpenSaved }: ModalSavedNoteProps) => {
+const OpenSavedNoteModal = memo(({ savedNote, onOpenSaved }: ModalSavedNoteProps) => {
   return (
     <ModalProvider>
       <ModalTrigger className='shrink-0 rounded-full bg-white border border-blue-500 text-blue-500 text-sm font-semibold py-2 px-4'>
@@ -38,6 +38,6 @@ const ModalSavedNote = memo(({ savedNote, onOpenSaved }: ModalSavedNoteProps) =>
   );
 });
 
-ModalSavedNote.displayName = 'ModalSavedNote';
+OpenSavedNoteModal.displayName = 'OpenSavedNoteModal';
 
-export default ModalSavedNote;
+export default OpenSavedNoteModal;

--- a/app/(nav)/todos/[todoId]/note/[noteId]/page.tsx
+++ b/app/(nav)/todos/[todoId]/note/[noteId]/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from 'next/headers';
 import NoteForm from '../../_view/NoteForm';
+import { Note } from '@/lib/types/todo';
 
 export default async function Page({ params }: { params: { noteId: string } }) {
   const { noteId } = params;
@@ -9,12 +10,12 @@ export default async function Page({ params }: { params: { noteId: string } }) {
     headers: { Authorization: `Bearer ${accessToken?.value}` },
     cache: 'no-store',
   });
-  const body = await response.json();
+  const body: Partial<Note> = await response.json();
   const { title, content, linkUrl } = body;
 
   return (
     <main className='lg:flex h-screen w-screen'>
-      <NoteForm title={title} content={content} linkUrl={linkUrl} method='PATCH' noteId={noteId} />
+      <NoteForm title={title} content={content} linkUrl={linkUrl ?? ''} method='PATCH' noteId={noteId} />
     </main>
   );
 }

--- a/lib/types/todo.ts
+++ b/lib/types/todo.ts
@@ -50,7 +50,7 @@ export type Note = {
     title: string;
     id: number;
   };
-  linkUrl: string;
+  linkUrl: string | null;
   content: string;
   updatedAt: string;
   createdAt: string;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->

<!-- ex) [Home] 대시보드에서 ~~ 구현 -->

## ✅ 작업 내용
- 링크모달 인풋에 입력 시 렌더링 분리되도록 링크추가모달 컴포넌트와 모달 내 인풋 컴포넌트 분리
- submit 이벤트로 인풋값 참조하도록 form 컴포넌트 삽입

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항
Closes #189 

## ✍ 궁금한 것
