### PR TITLE
[ 대시보드 ] 할 일 / 목표 없을 시 화면에 메세지 출력

### DIFF
--- a/app/(nav)/dashboard/page.tsx
+++ b/app/(nav)/dashboard/page.tsx
@@ -7,7 +7,7 @@ import RecentTodo from '@/components/dashboard/RecentTodo';
 
 export default function DashboardPage() {
   return (
-    <PageContainer className={'max-w-[1200px] gap-4'}>
+    <PageContainer className={'max-w-[1200px] gap-4 flex flex-col'}>
       <div className='hidden sm:block lg:block'>
         <PageHeader title='대시보드' />
       </div>

--- a/components/dashboard/GoalTodo.tsx
+++ b/components/dashboard/GoalTodo.tsx
@@ -17,15 +17,20 @@ const GoalTodo = () => {
   }, [inView, fetchNextPage]);
 
   return (
-    <section className='flex mt-6 w-full'>
-      <div className='flex-col px-6 py-4 w-full h-auto min-h-[768px] bg-white rounded-xl border border-slate-100'>
+    <section className='flex mt-6 w-full pb-16 flex-grow'>
+      <div className='flex-col px-6 py-4 w-full h-auto bg-white rounded-xl border border-slate-100 relative'>
         <div className='flex items-center gap-2'>
           <div className='w-10 h-10 flex-shrink-0 bg-orange-500 rounded-[15px] grid place-content-center'>
             <IconDashboardFlag />
           </div>
           <p className='text-slate-800 text-lg font-semibold'>목표 별 할 일</p>
         </div>
-        <div className='flex-col mt-6 space-y-4'>
+        {data?.pages[0].totalCount === 0 && (
+          <span className='absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-sm text-slate-500'>
+            등록한 목표가 없어요
+          </span>
+        )}
+        <div className='flex-col mt-6 space-y-4 '>
           {data?.pages.map((page, idx) => (
             <div key={page.nextCursor || idx} className='flex-col mt-6 space-y-4'>
               {page.goals.map((goal: Goal) => (

--- a/components/dashboard/RecentTodo.tsx
+++ b/components/dashboard/RecentTodo.tsx
@@ -23,7 +23,12 @@ const RecentTodo = () => {
           <IconArrowRight />
         </Link>
       </div>
-      <div className='w-full'>
+      <div className='w-full h-full relative'>
+        {recentTodos?.totalCount === 0 && (
+          <span className='absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-sm text-slate-500'>
+            최근에 등록한 할 일이 없어요
+          </span>
+        )}
         {recentTodos?.todos.map((todo) => (
           <TodoItem data={todo} key={todo.id} viewGoal />
         ))}


### PR DESCRIPTION
## ✅ 작업 내용
- 데이터의 길이가 0일 때 각 영역에 화면에 메세지를 추가했습니다.
- 대시보드의 목표 별 할 일 영역의 높이를 flex-grow로 bottom margin을 제외한 남은 높이를 모두 차지하도록 변경했습니다.


## 📸 스크린샷 / GIF / Link
![image](https://github.com/user-attachments/assets/6333365d-9390-4920-9b7e-bd9cc474f9f0)

close #199