### PR TITLE
[ 로그인 & 회원가입 ] 서버관련 에러처리 

### DIFF
--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -7,6 +7,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { LoginFormData, loginSchema } from '@/lib/schemas/authSchemas';
 import { login } from '@/lib/api/login';
 import { setUserToStorage } from '@/lib/utils/auth';
+import { parseAuthError } from '@/lib/utils/parseError';
 
 const LoginForm: React.FC = () => {
   const {
@@ -26,24 +27,11 @@ const LoginForm: React.FC = () => {
       window.location.href = '/dashboard';
     } catch (error) {
       if (error instanceof Error) {
-        // 서버에서 받은 에러 메시지를 적절한 필드에 설정
-        if (error.message.includes('이메일')) {
-          setError('email', {
-            type: 'manual',
-            message: error.message,
-          });
-        } else if (error.message.includes('비밀번호')) {
-          setError('password', {
-            type: 'manual',
-            message: error.message,
-          });
-        } else {
-          // 일반적인 에러의 경우 비밀번호 필드에 표시 (임시)
-          setError('password', {
-            type: 'manual',
-            message: error.message,
-          });
-        }
+        const { field, message } = parseAuthError(error);
+        setError(field, {
+          type: 'manual',
+          message,
+        });
       }
     }
   };
@@ -67,6 +55,9 @@ const LoginForm: React.FC = () => {
       <Button className='w-full' type='submit' disabled={isSubmitting}>
         로그인하기
       </Button>
+      {errors.root?.serverError && (
+        <span className='mt-1 ml-4 text-red-700 text-xs sm:text-sm'>{errors.root?.serverError.message}</span>
+      )}
     </form>
   );
 };

--- a/components/SignUpForm.tsx
+++ b/components/SignUpForm.tsx
@@ -11,7 +11,7 @@ import IconCheck from '@/public/icons/IconCheck';
 import SignupSuccessModal from './modal/SignupSuccessModal';
 import { useEmailValidation } from '@/lib/hooks/useEmailValidation';
 import { SignupFormRequest } from '@/lib/types/auth';
-import { parseSignupError } from '@/lib/utils/parseError';
+import { parseAuthError } from '@/lib/utils/parseError';
 
 const SignUpForm: React.FC = () => {
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
@@ -43,7 +43,7 @@ const SignUpForm: React.FC = () => {
       setIsSuccessModalOpen(true);
     } catch (error) {
       if (error instanceof Error) {
-        const { field, message } = parseSignupError(error);
+        const { field, message } = parseAuthError(error);
         setError(field, {
           type: 'manual',
           message,

--- a/components/SignUpForm.tsx
+++ b/components/SignUpForm.tsx
@@ -64,6 +64,14 @@ const SignUpForm: React.FC = () => {
   useEffect(() => {
     const validateEmail = async (email: string) => {
       setIsEmailAvailable(false);
+      const hasKorean = /[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/.test(email);
+      if (hasKorean) {
+        setError('email', {
+          type: 'manual',
+          message: '이메일에 한글을 포함할 수 없습니다.',
+        });
+        return;
+      }
       try {
         // 여기에 이메일 검증 API 호출
         const password = 'passwordToTestEmail';
@@ -75,18 +83,17 @@ const SignUpForm: React.FC = () => {
           },
         });
 
-        if (response.status === 404) {
-          setError('email', {
-            type: 'manual',
-            message: '',
-          });
-          setIsEmailAvailable(true);
-          return;
-        }
-
         if (!response.ok) {
           const error = await response.json();
           console.log(error.message);
+          if (error.message.includes('가입')) {
+            setError('email', {
+              type: 'manual',
+              message: '',
+            });
+            setIsEmailAvailable(true);
+            return;
+          }
           if (error.message.includes('비밀번호가 올바르지')) {
             setError('email', {
               type: 'manual',

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -7,7 +7,8 @@ export const TABLET_BREAKPOINT = 1024;
 export const CONFIRMATION_ITEM_TEXTS = {
   goal: {
     title: '목표 삭제',
-    message: '목표를 삭제하시겠습니까?\n목표에 포함된 노트와 할 일이 모두 삭제됩니다.\n삭제된 목표는 복구할 수 없습니다.',
+    message:
+      '목표를 삭제하시겠습니까?\n목표에 포함된 노트와 할 일이 모두 삭제됩니다.\n삭제된 목표는 복구할 수 없습니다.',
   },
   note: {
     title: '노트 삭제',
@@ -21,4 +22,13 @@ export const CONFIRMATION_ITEM_TEXTS = {
     title: '노트가 없습니다',
     message: '노트를 생성하시겠습니까?',
   },
+};
+
+export const EMAIL_VALIDATION_DELAY = 1200;
+
+export const AUTH_ERROR_MESSAGES = {
+  EMAIL_KOREAN: '이메일에 한글을 포함할 수 없습니다.',
+  EMAIL_DUPLICATE: '이미 사용중인 이메일입니다.',
+  EMAIL_VALIDATION_FAILED: '이메일 검증에 실패했습니다.',
+  SERVER_ERROR: '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
 };

--- a/lib/api/signUp.ts
+++ b/lib/api/signUp.ts
@@ -1,7 +1,7 @@
 import { API_BASE_URL } from '@/constants';
-import { SignupFormData, SignupResponse } from '../types/auth';
+import { SignupFormRequest, SignupResponse } from '../types/auth';
 
-export const signUp = async (data: SignupFormData): Promise<SignupResponse> => {
+export const signUp = async (data: SignupFormRequest): Promise<SignupResponse> => {
   const response = await fetch(`${API_BASE_URL}/user`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/lib/hooks/useEmailValidation.ts
+++ b/lib/hooks/useEmailValidation.ts
@@ -1,0 +1,116 @@
+import { useState, useEffect, useRef } from 'react';
+import { UseFormSetError } from 'react-hook-form';
+import { SignupFormData } from '../schemas/authSchemas';
+import { AUTH_ERROR_MESSAGES, EMAIL_VALIDATION_DELAY } from '@/constants';
+
+export const useEmailValidation = (email: string, setError: UseFormSetError<SignupFormData>) => {
+  const [isEmailAvailable, setIsEmailAvailable] = useState(false);
+  const timerRef = useRef<NodeJS.Timeout>();
+
+  const validateEmailFormat = (email: string) => {
+    const hasKorean = /[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/.test(email);
+    if (hasKorean) {
+      return {
+        type: 'korean',
+        message: AUTH_ERROR_MESSAGES.EMAIL_KOREAN,
+      };
+    }
+    return null;
+  };
+
+  const checkEmailAvailability = async (email: string) => {
+    try {
+      const response = await fetch('/4-4-dev/auth/login', {
+        method: 'POST',
+        body: JSON.stringify({ email, password: 'passwordToTestEmail' }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+
+        if (error.message.includes('가입')) {
+          return null; // 사용 가능한 이메일
+        }
+
+        if (error.message.includes('비밀번호가 올바르지')) {
+          return {
+            type: 'duplicate',
+            message: AUTH_ERROR_MESSAGES.EMAIL_DUPLICATE,
+          };
+        }
+
+        return {
+          type: 'server',
+          message: error.message || AUTH_ERROR_MESSAGES.EMAIL_VALIDATION_FAILED,
+        };
+      }
+
+      return {
+        type: 'invalid',
+        message: AUTH_ERROR_MESSAGES.EMAIL_VALIDATION_FAILED,
+      };
+    } catch (error) {
+      console.error(error);
+      return {
+        type: 'server',
+        message: AUTH_ERROR_MESSAGES.SERVER_ERROR,
+      };
+    }
+  };
+
+  useEffect(() => {
+    const validateEmail = async (email: string) => {
+      setIsEmailAvailable(false);
+
+      // 기본 포맷 검증
+      const formatError = validateEmailFormat(email);
+      if (formatError) {
+        setError('email', {
+          type: 'manual',
+          message: formatError.message,
+        });
+        return;
+      }
+
+      // 서버 측 검증
+      const availabilityError = await checkEmailAvailability(email);
+      if (availabilityError) {
+        setError('email', {
+          type: 'manual',
+          message: availabilityError.message,
+        });
+        return;
+      }
+
+      setError('email', {
+        type: 'manual',
+        message: '',
+      });
+      setIsEmailAvailable(true);
+    };
+
+    if (!email) {
+      setIsEmailAvailable(false);
+      return;
+    }
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
+    timerRef.current = setTimeout(() => {
+      validateEmail(email);
+    }, EMAIL_VALIDATION_DELAY);
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [email, setError]);
+
+  return { isEmailAvailable };
+};

--- a/lib/types/auth.ts
+++ b/lib/types/auth.ts
@@ -17,7 +17,7 @@ export interface LoginResponse {
   accessToken: string;
 }
 
-export interface SignupFormData {
+export interface SignupFormRequest {
   name: string;
   email: string;
   password: string;

--- a/lib/utils/parseError.ts
+++ b/lib/utils/parseError.ts
@@ -1,0 +1,31 @@
+import { AUTH_ERROR_MESSAGES } from '@/constants';
+
+export type ErrorField = 'email' | 'password' | 'root.serverError';
+
+export interface SignupError {
+  field: ErrorField;
+  message: string;
+}
+
+export const parseSignupError = (error: Error): SignupError => {
+  const errorMessage = error.message.toLowerCase();
+
+  if (errorMessage.includes('이메일')) {
+    return {
+      field: 'email',
+      message: error.message,
+    };
+  }
+
+  if (errorMessage.includes('비밀번호')) {
+    return {
+      field: 'password',
+      message: error.message,
+    };
+  }
+
+  return {
+    field: 'root.serverError',
+    message: AUTH_ERROR_MESSAGES.SERVER_ERROR,
+  };
+};

--- a/lib/utils/parseError.ts
+++ b/lib/utils/parseError.ts
@@ -2,12 +2,12 @@ import { AUTH_ERROR_MESSAGES } from '@/constants';
 
 export type ErrorField = 'email' | 'password' | 'root.serverError';
 
-export interface SignupError {
+export interface AuthError {
   field: ErrorField;
   message: string;
 }
 
-export const parseSignupError = (error: Error): SignupError => {
+export const parseAuthError = (error: Error): AuthError => {
   const errorMessage = error.message.toLowerCase();
 
   if (errorMessage.includes('이메일')) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -16,7 +16,7 @@ export async function middleware(request: NextRequest) {
   const isMainPage = pathname === '/';
   // 이미 로그인한 사용자가 로그인/회원가입 페이지에 접근하는 경우
   if (guestOnlyPages.has(pathname) || isMainPage) {
-    if (accessToken) {
+    if (accessToken || refreshToken) {
       return NextResponse.redirect(new URL('/dashboard', request.url));
     }
   }


### PR DESCRIPTION
close #196 
## ✅ 작업 내용
로그인 회원가입
- 에러메시지를 상수처리 했습니다
- 에러 메시지를 잡아주는 함수를 만들어 재사용성을 늘렸습니다
- 서버 에러를 통합하는 메시지로 표시하게 하였습니다.
미들웨어
- 리프래쉬 토큰이 있음에도 메인화면 및 로그인, 회원가입 페이지에 접근 가능한 것을 접근하지 못하게 수정하였습니다.
## 📸 스크린샷 / GIF / Link


![스크린샷 2024-11-05 101939](https://github.com/user-attachments/assets/a5400949-ac7e-4272-94b9-ad130fba7547)
