### PR TITLE
[ NAV ] 모바일, 태블릿에서 페이지 이동시에만 NAV가 접히도록 변경

### DIFF
--- a/components/nav/NavBar.tsx
+++ b/components/nav/NavBar.tsx
@@ -14,6 +14,7 @@ import { SheetContent, SheetProvider, SheetTrigger } from '../common/Sheet';
 import { useEffect, useRef, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
+import { TABLET_BREAKPOINT } from '@/constants';
 
 type widthType = 'mobile' | 'tablet' | 'desktop';
 
@@ -45,12 +46,14 @@ const NavBar = () => {
     }
   }, [isNavOpen, isSheetNavOpen]);
 
-  // 페이지 이동 시 nav를 닫음
+  // 페이지 이동 시
   useEffect(() => {
     // 첫 마운트 이후에만(페이지 이동시에만)실행
     if (hasMounted.current) {
-      setIsNavOpen(false);
-      setIsSheetNavOpen(false);
+      // 모바일, 태블릿에서 페이지 이동시 열려있던 nav를 닫음
+      if (window.innerWidth < TABLET_BREAKPOINT) {
+        setIsSheetNavOpen(false);
+      }
       setCurrentPageLabel(document.title.split('|')[0].trim());
     } else {
       hasMounted.current = true;


### PR DESCRIPTION
## ✅ 작업 내용
페이지 이동시 펼쳐져있던 nav가 접히는것이 좋다고 생각했는데, 열어둔 nav가 자꾸 닫히니 불편함을 느껴 이전 상태를 유지하도록 변경했습니다.

- 모바일: nav가 전체화면이기때문에 페이지 이동시 반드시 접혀야합니다.
- 태블릿: nav가 시트(모달) 처럼 구성되어있기 때문에 페이지 이동시 접혀야합니다.
- 데스크탑: 데스크탑의 경우 열어둔 nav를 페이지 이동시마다 접는 기능이 불필요하다고 생각되어 제거했습니다.

close #208 