### PR TITLE
[ 노트 모아보기 & 아이콘 ] 스타일링 추가

### DIFF
--- a/components/common/todoItem/TodoIcon.tsx
+++ b/components/common/todoItem/TodoIcon.tsx
@@ -73,7 +73,7 @@ const TodoIcon: React.FC<TodoIconProps> = ({ data }) => {
         {data.fileUrl && (
           <IconFile
             className='sm:cursor-pointer group'
-            circleClassName='sm:group-hover:fill-slate-200'
+            circleClassName='sm:group-hover:fill-blue-200'
             onClick={() => handleDownloadFile(data.fileUrl)}
           />
         )}
@@ -87,14 +87,14 @@ const TodoIcon: React.FC<TodoIconProps> = ({ data }) => {
         {data.noteId && (
           <IconNoteView
             className='sm:cursor-pointer cursor-default group'
-            circleClassName='sm:group-hover:fill-slate-200'
+            circleClassName='sm:group-hover:fill-orange-200'
             onClick={handleSheet}
           />
         )}
         <button onClick={handleClickMutateNote}>
           <IconNoteWrite
             className='sm:cursor-pointer w-0 sm:w-auto group'
-            circleClassName='sm:group-hover:fill-slate-200'
+            circleClassName='sm:group-hover:fill-orange-200'
           />
         </button>
         <div className='flex justify-center items-center'>
@@ -102,7 +102,7 @@ const TodoIcon: React.FC<TodoIconProps> = ({ data }) => {
             icon={IconKebabWithCircle}
             dropdownList={['수정하기', '삭제하기']}
             onItemClick={handleDropdaownMenuClick}
-            className='sm:hover:stroke-slate-200 sm:hover:fill-slate-200 cursor-pointer w-0 sm:w-auto'
+            iconClassName='sm:hover:stroke-blue-200 cursor-pointer w-0 sm:w-auto'
           />
         </div>
       </div>

--- a/components/drawer/TodoContentsDrawer/ActionButtons.tsx
+++ b/components/drawer/TodoContentsDrawer/ActionButtons.tsx
@@ -27,7 +27,7 @@ const ActionButtons = ({ data, onNoteView }: TodoActionButtonsProps) => {
 
   const handleGetNoteUrl = (type: 'create' | 'edit') => {
     const baseUrl =
-      type === 'create' ? `/todos/${data.id}/${data.noteId}/create` : `todos/${data.id}/note/${data.noteId}`;
+      type === 'create' ? `/todos/${data.id}/${data.noteId}/create` : `/todos/${data.id}/note/${data.noteId}`;
     const params = new URLSearchParams({
       todo: data.title,
       goal: data.goal?.title ?? '목표 없음',
@@ -73,7 +73,11 @@ const ActionButtons = ({ data, onNoteView }: TodoActionButtonsProps) => {
       {actionButtons
         .filter((button) => button.condition !== false)
         .map((button, index) => (
-          <div key={index} className='flex space-x-2 cursor-pointer hover:underline' onClick={button.onClick}>
+          <div
+            key={index}
+            className='flex items-center space-x-3 cursor-pointer text-xl hover:underline'
+            onClick={button.onClick}
+          >
             {button.icon}
             <p>{button.label}</p>
           </div>

--- a/components/drawer/TodoContentsDrawer/TodoContentsDrawer.tsx
+++ b/components/drawer/TodoContentsDrawer/TodoContentsDrawer.tsx
@@ -7,6 +7,8 @@ import ActionButtons from './ActionButtons';
 import TodoEditModal from '@/components/modal/todoModal/TodoEditModal';
 import NoteViewSheet from '@/components/sheet/NoteViewSheet';
 import ConfirmationModal from '@/components/modal/ConfirmationModal';
+import IconTrash from '@/public/icons/IconTrash';
+import IconEditTodo from '@/public/icons/IconEditTodo';
 
 interface TodoContentsDrawerProps {
   isOpen: boolean;
@@ -25,10 +27,20 @@ const TodoContentsDrawer: React.FC<TodoContentsDrawerProps> = ({ isOpen, onChang
       <SheetProvider isOpen={isOpen} onChangeIsOpen={onChangeIsOpen}>
         <SheetContent position='bottom' className='w-full h-auto'>
           <div className='flex flex-col space-y-6'>
-            <h2 className='text-center'>{data.title}</h2>
+            <h2 className='text-center text-xl font-bold'>{data.title}</h2>
             <div className='flex justify-around'>
-              <Button onClick={() => setIsEditTodoModalOpen(true)}>수정하기</Button>
-              <Button onClick={() => setIsConfirmationModalOpen(true)}>삭제하기</Button>
+              <Button className='text-slate-800' variant='outlined' onClick={() => setIsEditTodoModalOpen(true)}>
+                <IconEditTodo className='mr-1.5' />
+                수정하기
+              </Button>
+              <Button
+                className='border-red-500 text-slate-800'
+                variant='outlined'
+                onClick={() => setIsConfirmationModalOpen(true)}
+              >
+                <IconTrash className='mr-1.5' />
+                삭제하기
+              </Button>
             </div>
             <ActionButtons data={data} onNoteView={() => setIsNoteViewOpen(true)} />
           </div>

--- a/components/drawer/TodoContentsDrawer/TodoContentsDrawer.tsx
+++ b/components/drawer/TodoContentsDrawer/TodoContentsDrawer.tsx
@@ -28,17 +28,19 @@ const TodoContentsDrawer: React.FC<TodoContentsDrawerProps> = ({ isOpen, onChang
         <SheetContent position='bottom' className='w-full h-auto'>
           <div className='flex flex-col space-y-6'>
             <h2 className='text-center text-xl font-bold'>{data.title}</h2>
-            <div className='flex justify-around'>
-              <Button className='text-slate-800' variant='outlined' onClick={() => setIsEditTodoModalOpen(true)}>
-                <IconEditTodo className='mr-1.5' />
+            <div className='flex justify-around gap-2'>
+              <Button
+                className='text-slate-800 flex-col w-full bg-slate-100'
+                onClick={() => setIsEditTodoModalOpen(true)}
+              >
+                <IconEditTodo className='mb-1' />
                 수정하기
               </Button>
               <Button
-                className='border-red-500 text-slate-800'
-                variant='outlined'
+                className='border-red-500 text-slate-800 flex-col w-full bg-slate-100'
                 onClick={() => setIsConfirmationModalOpen(true)}
               >
-                <IconTrash className='mr-1.5' />
+                <IconTrash className='mb-1' />
                 삭제하기
               </Button>
             </div>

--- a/components/drawer/TodoContentsDrawer/TodoContentsDrawer.tsx
+++ b/components/drawer/TodoContentsDrawer/TodoContentsDrawer.tsx
@@ -25,7 +25,7 @@ const TodoContentsDrawer: React.FC<TodoContentsDrawerProps> = ({ isOpen, onChang
   return (
     <>
       <SheetProvider isOpen={isOpen} onChangeIsOpen={onChangeIsOpen}>
-        <SheetContent position='bottom' className='w-full h-auto'>
+        <SheetContent position='bottom' className='w-full h-auto rounded-t-xl'>
           <div className='flex flex-col space-y-6'>
             <h2 className='text-center text-xl font-bold'>{data.title}</h2>
             <div className='flex justify-around gap-2'>

--- a/components/notes/NoteItem.tsx
+++ b/components/notes/NoteItem.tsx
@@ -39,7 +39,7 @@ const NoteItem: React.FC<NoteItemProps> = ({ note }) => {
   return (
     <>
       <div
-        className='p-6 bg-white flex flex-col space-y-4 rounded-xl group cursor-pointer'
+        className='p-6 bg-white flex flex-col space-y-4 rounded-xl group cursor-pointer hover:shadow-lg transition-all duration-200'
         onClick={handleClickTrigger}
       >
         <div className='flex justify-between items-center'>

--- a/public/icons/IconEditTodo.tsx
+++ b/public/icons/IconEditTodo.tsx
@@ -1,0 +1,31 @@
+import { SVGProps } from 'react';
+
+interface IconEditTodoProps extends SVGProps<SVGSVGElement> {
+  pathClassName?: string;
+}
+
+const IconEditTodo = ({ pathClassName, ...props }: IconEditTodoProps) => (
+  <svg
+    width='24'
+    height='24'
+    viewBox='0 0 1024 1024'
+    xmlns='http://www.w3.org/2000/svg'
+    fill='#000000'
+    aria-labelledby='EditTodoIconTitle'
+    {...props}
+  >
+    <title id='EditTodoIconTitle'>수정하기</title>
+    <path
+      d='M930.56 192l-138.56-133.12A91.84 91.84 0 0 0 723.52 32a96 96 0 0 0-67.2 29.44L124.48 615.04a32 32 0 0 0-5.76 8.96V628.8L32 947.84a32 32 0 0 0 32 40 32 32 0 0 0 9.28 0l314.88-96h4.48a32 32 0 0 0 8.64-6.08l176.96-184.32a32 32 0 0 0-46.08-44.16l-155.2 160L192 636.48 704 105.92a32 32 0 0 1 22.4-9.92 33.92 33.92 0 0 1 22.72 8.96l138.56 133.12a32 32 0 0 1 0 45.12l-23.68 23.04A32 32 0 0 0 911.04 352l22.08-23.04A96 96 0 0 0 930.56 192zM108.8 908.48l55.68-210.24 152.32 146.24z'
+      className={pathClassName}
+      fill='#231815'
+    />
+    <path
+      d='M688.32 462.72l-66.56 69.12A32 32 0 1 0 668.16 576L736 507.2a32 32 0 0 0-46.08-44.16zM822.72 369.92a32 32 0 0 0-45.12 0 32 32 0 0 0-7.04 10.56A32 32 0 0 0 777.6 416a32 32 0 0 0 22.4 9.28 32 32 0 0 0 12.48-2.24 32 32 0 0 0 10.24-7.04 32 32 0 0 0 7.04-34.88 38.4 38.4 0 0 0-7.04-11.2z'
+      className={pathClassName}
+      fill='#231815'
+    />
+  </svg>
+);
+
+export default IconEditTodo;

--- a/public/icons/IconFile.tsx
+++ b/public/icons/IconFile.tsx
@@ -6,7 +6,15 @@ interface IconFileProps extends SVGProps<SVGSVGElement> {
 }
 
 const IconFile = ({ circleClassName, pathClassName, ...props }: IconFileProps) => (
-  <svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg' {...props}>
+  <svg
+    width='24'
+    height='24'
+    viewBox='0 0 24 24'
+    fill='none'
+    xmlns='http://www.w3.org/2000/svg'
+    aria-labelledby='fileTitle'
+    {...props}
+  >
     <title id='fileTitle'>파일 다운로드</title>
     <circle cx='12' cy='12' r='12' className={circleClassName} fill='#60A5FA' />
     <path

--- a/public/icons/IconFile.tsx
+++ b/public/icons/IconFile.tsx
@@ -7,11 +7,12 @@ interface IconFileProps extends SVGProps<SVGSVGElement> {
 
 const IconFile = ({ circleClassName, pathClassName, ...props }: IconFileProps) => (
   <svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg' {...props}>
-    <circle cx='12' cy='12' r='12' className={circleClassName} fill='#F8FAFC' />
+    <title id='fileTitle'>파일 다운로드</title>
+    <circle cx='12' cy='12' r='12' className={circleClassName} fill='#60A5FA' />
     <path
       d='M8.26699 7.66667C8.26699 7.62985 8.29684 7.6 8.33366 7.6H12.0003H13.8645C13.8837 7.6 13.902 7.6083 13.9147 7.62277L14.8801 8.72614L15.7176 9.70323C15.728 9.71531 15.7337 9.7307 15.7337 9.74662V12V16.3333C15.7337 16.3702 15.7038 16.4 15.667 16.4H8.33366C8.29684 16.4 8.26699 16.3702 8.26699 16.3333V7.66667Z'
       className={pathClassName}
-      stroke='#64748B'
+      stroke='#F8FAFC'
       strokeWidth='1.2'
     />
   </svg>

--- a/public/icons/IconKebabWithCircle.tsx
+++ b/public/icons/IconKebabWithCircle.tsx
@@ -2,8 +2,16 @@ import React, { SVGProps } from 'react';
 
 export const IconKebabWithCircle = (props: SVGProps<SVGSVGElement>) => {
   return (
-    <svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' {...props}>
-      <circle cx='12' cy='12' r='10' fill='#F8FAFC' />
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      width='24'
+      height='24'
+      viewBox='0 0 24 24'
+      fill='none'
+      className='group'
+      {...props}
+    >
+      <circle cx='12' cy='12' r='12' fill='#F8FAFC' />
       <g transform='translate(10, 6)'>
         <svg xmlns='http://www.w3.org/2000/svg' width='4' height='12' viewBox='0 0 4 12' fill='none'>
           <circle

--- a/public/icons/IconLink.tsx
+++ b/public/icons/IconLink.tsx
@@ -6,7 +6,15 @@ interface IconLinkProps extends SVGProps<SVGSVGElement> {
 }
 
 const IconLink = ({ circleClassName, pathClassName, ...props }: IconLinkProps) => (
-  <svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg' {...props}>
+  <svg
+    width='24'
+    height='24'
+    viewBox='0 0 24 24'
+    fill='none'
+    xmlns='http://www.w3.org/2000/svg'
+    aria-labelledby='linkTitle'
+    {...props}
+  >
     <title id='linkTitle'>링크 들어가기</title>
     <circle className={circleClassName} cx='12' cy='12' r='12' fill='#60A5FA' />
     <path

--- a/public/icons/IconLink.tsx
+++ b/public/icons/IconLink.tsx
@@ -7,11 +7,12 @@ interface IconLinkProps extends SVGProps<SVGSVGElement> {
 
 const IconLink = ({ circleClassName, pathClassName, ...props }: IconLinkProps) => (
   <svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg' {...props}>
-    <circle className={circleClassName} cx='12' cy='12' r='12' fill='#DBEAFE' />
+    <title id='linkTitle'>링크 들어가기</title>
+    <circle className={circleClassName} cx='12' cy='12' r='12' fill='#60A5FA' />
     <path
       className={pathClassName}
       d='M13.3337 10.6673L10.667 13.334'
-      stroke='#60A5FA'
+      stroke='#F8FAFC'
       strokeWidth='1.33333'
       strokeLinecap='round'
       strokeLinejoin='round'
@@ -19,7 +20,7 @@ const IconLink = ({ circleClassName, pathClassName, ...props }: IconLinkProps) =
     <path
       className={pathClassName}
       d='M14.6663 12.6673L15.9997 11.334C16.9201 10.4135 16.9201 8.92113 15.9997 8.00065V8.00065C15.0792 7.08018 13.5868 7.08018 12.6663 8.00065L11.333 9.33398M9.33301 11.334L7.99967 12.6673C7.0792 13.5878 7.0792 15.0802 7.99967 16.0007V16.0007C8.92015 16.9211 10.4125 16.9211 11.333 16.0006L12.6663 14.6673'
-      stroke='#60A5FA'
+      stroke='#F8FAFC'
       strokeWidth='1.33333'
       strokeLinecap='round'
     />

--- a/public/icons/IconNoteView.tsx
+++ b/public/icons/IconNoteView.tsx
@@ -6,27 +6,36 @@ interface IconNoteViewProps extends SVGProps<SVGSVGElement> {
 }
 
 const IconNoteView = ({ circleClassName, pathClassName, ...props }: IconNoteViewProps) => (
-  <svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg' {...props}>
-    <circle className={circleClassName} cx='12' cy='12' r='12' fill='#F8FAFC' />
-    <rect x='7.5' y='6.90039' width='9' height='10.3846' rx='1.38462' fill='#60A5FA' />
+  <svg
+    width='24'
+    height='24'
+    viewBox='0 0 24 24'
+    fill='none'
+    xmlns='http://www.w3.org/2000/svg'
+    aria-labelledby='noteViewTitle'
+    {...props}
+  >
+    <title id='noteViewTitle'>노트보기</title>
+    <circle className={circleClassName} cx='12' cy='12' r='12' fill='#FF9F43' />
+    <rect x='7.5' y='6.90039' width='9' height='10.3846' rx='1.38462' fill='#F8FAFC' />
     <path
       className={pathClassName}
       d='M9.57715 10.0156H14.4233'
-      stroke='white'
+      stroke='#FF9F43'
       strokeWidth='0.969231'
       strokeLinecap='round'
     />
     <path
       className={pathClassName}
       d='M9.57715 12.0918H14.4233'
-      stroke='white'
+      stroke='#FF9F43'
       strokeWidth='0.969231'
       strokeLinecap='round'
     />
     <path
       className={pathClassName}
       d='M9.57715 14.1699H14.4233'
-      stroke='white'
+      stroke='#FF9F43'
       strokeWidth='0.969231'
       strokeLinecap='round'
     />

--- a/public/icons/IconNoteWrite.tsx
+++ b/public/icons/IconNoteWrite.tsx
@@ -7,11 +7,12 @@ interface IconNoteWriteProps extends SVGProps<SVGSVGElement> {
 
 const IconNoteWrite = ({ circleClassName, pathClassName, ...props }: IconNoteWriteProps) => (
   <svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg' {...props}>
-    <circle className={circleClassName} cx='12' cy='12' r='12' fill='#F8FAFC' />
+    <title id='noteWriteTitle'>노트 수정하기&생성하기 </title>
+    <circle className={circleClassName} cx='12' cy='12' r='12' fill='#FF9F43' />
     <path
       className={pathClassName}
       d='M15.9375 8.76642C16.2136 8.28812 16.0498 7.67653 15.5715 7.40039L14.6974 6.89576C14.2191 6.61962 13.6075 6.78349 13.3314 7.26178L9.11674 14.5618C9.00321 14.7584 8.95998 14.9879 8.99417 15.2124L9.11579 16.011C9.21228 16.6445 9.8714 17.025 10.4683 16.7918L11.2207 16.4979C11.4322 16.4152 11.6093 16.2631 11.7228 16.0664L15.9375 8.76642Z'
-      fill='#3B82F6'
+      fill='#F8FAFC'
     />
   </svg>
 );

--- a/public/icons/IconNoteWrite.tsx
+++ b/public/icons/IconNoteWrite.tsx
@@ -6,7 +6,15 @@ interface IconNoteWriteProps extends SVGProps<SVGSVGElement> {
 }
 
 const IconNoteWrite = ({ circleClassName, pathClassName, ...props }: IconNoteWriteProps) => (
-  <svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg' {...props}>
+  <svg
+    width='24'
+    height='24'
+    viewBox='0 0 24 24'
+    fill='none'
+    xmlns='http://www.w3.org/2000/svg'
+    aria-labelledby='noteWriteTitle'
+    {...props}
+  >
     <title id='noteWriteTitle'>노트 수정하기&생성하기 </title>
     <circle className={circleClassName} cx='12' cy='12' r='12' fill='#FF9F43' />
     <path

--- a/public/icons/IconTrash.tsx
+++ b/public/icons/IconTrash.tsx
@@ -1,0 +1,31 @@
+import { SVGProps } from 'react';
+
+interface TrashIconProps extends SVGProps<SVGSVGElement> {
+  pathClassName?: string;
+}
+
+const TrashIcon = ({ pathClassName, ...props }: TrashIconProps) => (
+  <svg
+    width='24'
+    height='24'
+    viewBox='0 0 1024 1024'
+    fill='none'
+    xmlns='http://www.w3.org/2000/svg'
+    aria-labelledby='trashTitle'
+    {...props}
+  >
+    <title id='trashTitle'>삭제하기</title>
+    <path
+      d='M960 160h-291.2a160 160 0 0 0-313.6 0H64a32 32 0 0 0 0 64h896a32 32 0 0 0 0-64zM512 96a96 96 0 0 1 90.24 64h-180.48A96 96 0 0 1 512 96zM844.16 290.56a32 32 0 0 0-34.88 6.72A32 32 0 0 0 800 320a32 32 0 1 0 64 0 33.6 33.6 0 0 0-9.28-22.72 32 32 0 0 0-10.56-6.72zM832 416a32 32 0 0 0-32 32v96a32 32 0 0 0 64 0v-96a32 32 0 0 0-32-32zM832 640a32 32 0 0 0-32 32v224a32 32 0 0 1-32 32H256a32 32 0 0 1-32-32V320a32 32 0 0 0-64 0v576a96 96 0 0 0 96 96h512a96 96 0 0 0 96-96v-224a32 32 0 0 0-32-32z'
+      className={pathClassName}
+      fill='#FF6B6B'
+    />
+    <path
+      d='M384 768V352a32 32 0 0 0-64 0v416a32 32 0 0 0 64 0zM544 768V352a32 32 0 0 0-64 0v416a32 32 0 0 0 64 0zM704 768V352a32 32 0 0 0-64 0v416a32 32 0 0 0 64 0z'
+      className={pathClassName}
+      fill='#FF6B6B'
+    />
+  </svg>
+);
+
+export default TrashIcon;


### PR DESCRIPTION
close #211 
## ✅ 작업 내용
1. 노트모아보기 페이지
- 각 카드 호버하면 그림자가 보입니다(피그마에서는 shadow였지만 티도 안나서 shadow-lg 변경)
2. 아이콘
- 아이콘 색을 배경에 입혔습니다. 노트 관련 아이콘에 주황색을 주어서 차이를 주었습니다.
- 다른 아이콘 크기와 맞게 캐밥 아이콘 서클 반지름 12에 맞게 변경했습니다.
- 아이콘 수정하기, 삭제하기를 추가하였습니다.
- 호버시 색상을 바꿨습니다.
- 호버시 아이콘 타이틀이 나오게 하였습니다.
3. [components/drawer/TodoContentsDrawer/TodoContentsDrawer.tsx](https://github.com/FESI-4-4/slid-todo/compare/feature/211?expand=1#diff-260ba7f1a7bfd4005e7596f961bded1eba5b7ae1b7e384d0c234acfe704ea228)
- 크기를 전체적으로 키웠습니다.
4. 모바일에서 노트수정 클릭시 잘못된 url이동을 수정하였습니다.

## 📸 스크린샷 / GIF / Link
![스크린샷 2024-11-05 143657](https://github.com/user-attachments/assets/d7930cca-9e1e-4a01-9e17-b3e9c9971446)
![스크린샷 2024-11-05 143637](https://github.com/user-attachments/assets/cdfd4529-e5f4-43cf-83be-1e6319847331)
![image](https://github.com/user-attachments/assets/c03d421c-f7b0-4ccb-8995-478b1acba436)


## 📌 이슈 사항

