### PR TITLE
[ 노트 ]노트 링크 삭제 기능 추가 외

### DIFF
--- a/app/(nav)/todos/[todoId]/_view/NoteFormSection.tsx
+++ b/app/(nav)/todos/[todoId]/_view/NoteFormSection.tsx
@@ -91,6 +91,8 @@ const NoteFormSection = ({
     [content]
   );
 
+  const handleDeleteLinkUrl = () => onSaveLinkUrl('');
+
   return (
     <NoteForm
       method={method}
@@ -147,9 +149,13 @@ const NoteFormSection = ({
                     {linkUrl}
                   </p>
                   <input type='hidden' name='linkUrl' value={linkUrl} />
-                  <div className='w-6 h-6 rounded-full flex justify-center items-center'>
+                  <button
+                    className='w-6 h-6 rounded-full flex justify-center items-center'
+                    type='button'
+                    onClick={handleDeleteLinkUrl}
+                  >
                     <IconClose />
-                  </div>
+                  </button>
                 </div>
               )}
               <TiptapEditor />

--- a/app/(nav)/todos/[todoId]/_view/NoteFormSection.tsx
+++ b/app/(nav)/todos/[todoId]/_view/NoteFormSection.tsx
@@ -159,26 +159,28 @@ const NoteFormSection = ({
                 </div>
               )}
               <TiptapEditor />
-              <div className='lg:max-w-[768px] border border-slate-200 rounded-full py-2.5 px-4 sticky bottom-4 left-4 right-4 bg-white flex gap-2 md:gap-4 overflow-auto scrollbar-width-none'>
-                <NoteFormEditorButtons />
-                <div className='grow flex justify-end'>
-                  <AddLinkModal linkUrl={linkUrl} onSave={onSaveLinkUrl} />
+              <div className='lg:max-w-[768px] border border-slate-200 rounded-full py-2.5 px-4 sticky bottom-4 left-4 right-4 bg-white scrollbar-width-none overflow-visible'>
+                <div className='flex gap-2 md:gap-4 w-full overflow-auto scrollbar-width-none'>
+                  <NoteFormEditorButtons />
+                  <div className='grow flex justify-end'>
+                    <AddLinkModal linkUrl={linkUrl} onSave={onSaveLinkUrl} />
+                  </div>
                 </div>
+                {savedToast && (
+                  <div className='max-w-[768px] absolute -top-2 left-0 right-0 -translate-y-full bg-blue-50 text-blue-500 rounded-full py-2.5 px-6 flex gap-2 items-center'>
+                    <IconCheck />
+                    <p className='font-semibold text-sm'>
+                      임시 저장이 완료되었습니다{' '}
+                      <span className='text-xs pointerfont-medium'>
+                        ㆍ <SecondsTimer at={new Date(savedAt ?? 0)} />초 전
+                      </span>
+                    </p>
+                  </div>
+                )}
               </div>
             </>
           }
         />
-        {savedToast && (
-          <div className='max-w-[768px] fixed lg:sticky bottom-0 left-4 right-4 -translate-y-[155%] bg-blue-50 text-blue-500 rounded-full py-2.5 px-6 flex gap-2 items-center'>
-            <IconCheck />
-            <p className='font-semibold text-sm'>
-              임시 저장이 완료되었습니다{' '}
-              <span className='text-xs pointerfont-medium'>
-                ㆍ <SecondsTimer at={new Date(savedAt ?? 0)} />초 전
-              </span>
-            </p>
-          </div>
-        )}
       </div>
     </NoteForm>
   );

--- a/app/(nav)/todos/[todoId]/create/page.tsx
+++ b/app/(nav)/todos/[todoId]/create/page.tsx
@@ -2,7 +2,7 @@ import NoteFormSections from '../_view/NoteFormSections';
 
 export default function Page() {
   return (
-    <main className='lg:flex h-screen w-screen'>
+    <main className='lg:flex h-screen'>
       <NoteFormSections />
     </main>
   );


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->

<!-- ex) [Home] 대시보드에서 ~~ 구현 -->

## ✅ 작업 내용
[노트 링크 삭제 기능 추가](https://github.com/FESI-4-4/slid-todo/commit/c3a49c263af8d609cdc8446fadad2dda2f79dcab)
[노트생성페이지 횡스크롤 삭제](https://github.com/FESI-4-4/slid-todo/pull/227/commits/a862efb28c1fcaf8b9c5b0d5cfac73637eb0517e)
[임시저장완료토스트 위치 조정](https://github.com/FESI-4-4/slid-todo/pull/227/commits/ff2df183c43d468b48ca942c728b38574a217880)

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항
Closes #225 
Closes #226 

## ✍ 궁금한 것
