### PR TITLE
[ 에러 관련 ] 에러 처리 중앙화

### DIFF
--- a/app/(nav)/todos/[todoId]/note/[noteId]/page.tsx
+++ b/app/(nav)/todos/[todoId]/note/[noteId]/page.tsx
@@ -1,18 +1,18 @@
 import { cookies } from 'next/headers';
 import NoteFormSections from '../../_view/NoteFormSections';
 import { SingleNote } from '@/lib/types/todo';
+import baseFetch from '@/lib/api/baseFetch';
 
 export default async function Page({ params }: { params: { noteId: string } }) {
   const { noteId } = params;
   const accessToken = cookies().get('accessToken');
 
-  const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/notes/${noteId}`, {
+  const response: Partial<SingleNote> = await baseFetch(`${process.env.NEXT_PUBLIC_BASE_URL}/notes/${noteId}`, {
     headers: { Authorization: `Bearer ${accessToken?.value}` },
     cache: 'no-store',
   });
-  const body: Partial<SingleNote> = await response.json();
-  const { title, content, linkUrl } = body;
 
+  const { title, content, linkUrl } = response;
   return (
     <main className='lg:flex h-screen'>
       <NoteFormSections title={title} content={content} linkUrl={linkUrl ?? ''} method='PATCH' noteId={noteId} />

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import Button from '@/components/common/ButtonSlid';
+import MainLogo from '@/public/images/MainLogo';
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className='min-h-screen bg-gradient-to-b from-blue-100 to-purple-100 flex flex-col items-center justify-center p-4'>
+      <MainLogo className={`mb-[60px]`} />
+      <div className='bg-white rounded-lg shadow-xl p-8 max-w-md w-full text-center'>
+        {/* <Image
+          src='/'
+          alt=' 404 이미지'
+          className='mx-auto mb-6 rounded-full'
+          width={200}
+          height={200}
+        /> */}
+        <h2 className='text-2xl font-semibold text-gray-800 mb-4'>앗! 페이지를 찾을 수 없어요</h2>
+        <p className='text-gray-600 mb-8'>찾으시는 페이지가 사라졌거나 잘못된 주소를 입력하셨어요.</p>
+        <div className='flex flex-col sm:flex-row justify-center gap-4'>
+          <Button onClick={() => window.history.back()} className='flex items-center justify-center'>
+            뒤로 가기
+          </Button>
+          <Button className='flex items-center justify-center' variant='outlined'>
+            <Link href='/'>홈으로 가기</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -8,6 +8,7 @@ import { LoginFormData, loginSchema } from '@/lib/schemas/authSchemas';
 import { login } from '@/lib/api/login';
 import { setUserToStorage } from '@/lib/utils/auth';
 import { parseAuthError } from '@/lib/utils/parseError';
+import { HttpError } from '@/lib/api/errorHandlers';
 
 const LoginForm: React.FC = () => {
   const {
@@ -26,7 +27,7 @@ const LoginForm: React.FC = () => {
       setUserToStorage(response.user);
       window.location.href = '/dashboard';
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof HttpError) {
         const { field, message } = parseAuthError(error);
         setError(field, {
           type: 'manual',

--- a/components/SignUpForm.tsx
+++ b/components/SignUpForm.tsx
@@ -12,6 +12,7 @@ import SignupSuccessModal from './modal/SignupSuccessModal';
 import { useEmailValidation } from '@/lib/hooks/useEmailValidation';
 import { SignupFormRequest } from '@/lib/types/auth';
 import { parseAuthError } from '@/lib/utils/parseError';
+import { HttpError } from '@/lib/api/errorHandlers';
 
 const SignUpForm: React.FC = () => {
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
@@ -42,7 +43,7 @@ const SignUpForm: React.FC = () => {
       console.log(response);
       setIsSuccessModalOpen(true);
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof HttpError) {
         const { field, message } = parseAuthError(error);
         setError(field, {
           type: 'manual',

--- a/components/common/todoItem/TodoTitle.tsx
+++ b/components/common/todoItem/TodoTitle.tsx
@@ -18,7 +18,7 @@ const TodoTitle: React.FC<TodoTitleProps> = ({ data }) => {
   const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
   const router = useRouter();
   const handleLinkCreateNote = () => {
-    router.push(`/todos/${data.id}/note/create?todo=${data.title}&goal=${data.goal?.title ?? '목표 없음'}`);
+    router.push(`/todos/${data.id}/create?todo=${data.title}&goal=${data.goal?.title ?? '목표 없음'}`);
   };
   const handleTitleClick = () => {
     if (window.innerWidth >= MOBILE_BREAKPOINT) {

--- a/components/notes/NotesContent.tsx
+++ b/components/notes/NotesContent.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import NoteGoalTitle from './NoteGoalTitle';
 import NotesList from './NotesList';
 import baseFetch from '@/lib/api/baseFetch';
+import { HttpError } from '@/lib/api/errorHandlers';
 
 interface NotesContentProps {
   goalId: string;
@@ -22,7 +23,9 @@ const NotesContent: React.FC<NotesContentProps> = ({ goalId }) => {
         const goalData = await baseFetch(`/4-4-dev/goals/${goalId}`);
         setGoalTitle(goalData.title);
       } catch (error) {
-        console.error('Error fetching goal title:', error);
+        if (error instanceof HttpError) {
+          console.error('Error fetching goal title:', error.message);
+        }
       }
     };
 

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -32,3 +32,5 @@ export const AUTH_ERROR_MESSAGES = {
   EMAIL_VALIDATION_FAILED: '이메일 검증에 실패했습니다.',
   SERVER_ERROR: '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
 };
+
+export const REDIRECT_ON_404_PATHS = ['/4-4-dev/goals/'];

--- a/lib/api/baseFetch.ts
+++ b/lib/api/baseFetch.ts
@@ -1,9 +1,22 @@
+import { handleHttpError, HttpError } from './errorHandlers';
+
 const baseFetch = async (URL: string = '', options?: RequestInit) => {
-  const response = await fetch(URL, { headers: { 'Content-Type': 'application/json' }, ...options });
+  try {
+    const response = await fetch(URL, { headers: { 'Content-Type': 'application/json' }, ...options });
+    if (response.status === 204) return; // 기존에 있던 건 그대로 두었습니다.
+    const data = await response.json();
 
-  if (response.status === 204) return;
-
-  return await response.json();
+    if (!response.ok) {
+      handleHttpError(data, response.status, URL);
+    }
+    return data;
+  } catch (error) {
+    if (error instanceof HttpError) {
+      throw error; // 이미 처리된 HTTP 에러는 그대로 전파
+    }
+    // 네트워크 에러 등 기타 에러 처리
+    throw new HttpError(0, '네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요.', URL);
+  }
 };
 
 export default baseFetch;

--- a/lib/api/errorHandlers.ts
+++ b/lib/api/errorHandlers.ts
@@ -31,6 +31,7 @@ export const handleHttpError = (data: Data, status: number, url: string) => {
   if (status === 500) {
     handleServerError(url);
   }
+
   throw new HttpError(status, message, url);
 };
 
@@ -39,7 +40,6 @@ const handle404Error = (url: string) => {
     window.location.href = '/404';
     return;
   }
-  throw new HttpError(404, '요청하신 페이지를 찾을 수 없습니다.', url);
 };
 
 const handleServerError = (url: string) => {

--- a/lib/api/errorHandlers.ts
+++ b/lib/api/errorHandlers.ts
@@ -1,0 +1,48 @@
+import { REDIRECT_ON_404_PATHS } from '@/constants';
+import getDefaultErrorMessage from '../utils/getDefaultErrorMessage';
+
+const shouldRedirectOn404 = (url: string) => {
+  return REDIRECT_ON_404_PATHS.some((path) => url.includes(path));
+};
+
+export class HttpError extends Error {
+  constructor(public status: number, message: string, public url: string) {
+    super(message);
+    this.name = 'HttpError';
+  }
+}
+type Data = {
+  message?: string;
+} & unknown;
+
+export const handleHttpError = (data: Data, status: number, url: string) => {
+  // data타입은 서버에서 정의한 에러 응답 형식에 따라 다를 수 있기 때문에 unknown으로 처리
+  // slid 서버의 경우 { message: string } 형태로 에러 메시지를 전달하기 때문에 이와 같이 정의
+
+  const message = data.message ?? getDefaultErrorMessage(status);
+
+  if (status === 404) {
+    handle404Error(url);
+  }
+
+  if (status === 500) {
+    handleServerError(url);
+  }
+  throw new HttpError(status, message, url);
+};
+
+const handle404Error = (url: string) => {
+  if (shouldRedirectOn404(url)) {
+    window.location.href = '/404';
+    return;
+  }
+  throw new HttpError(404, '요청하신 페이지를 찾을 수 없습니다.', url);
+};
+
+const handleServerError = (url: string) => {
+  // 개발자를 위한 로깅
+  console.error(`Server error occurred at: ${url}`);
+  // 필요한 경우 외부 로깅 서비스로 에러 전송
+
+  throw new HttpError(500, '서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.', url);
+};

--- a/lib/api/errorHandlers.ts
+++ b/lib/api/errorHandlers.ts
@@ -20,6 +20,9 @@ export const handleHttpError = (data: Data, status: number, url: string) => {
   // slid 서버의 경우 { message: string } 형태로 에러 메시지를 전달하기 때문에 이와 같이 정의
 
   const message = data.message ?? getDefaultErrorMessage(status);
+  if (status === 400) {
+    handle404Error(url);
+  }
 
   if (status === 404) {
     handle404Error(url);

--- a/lib/api/login.ts
+++ b/lib/api/login.ts
@@ -1,25 +1,11 @@
 import { LoginFormData, LoginResponse } from '../types/auth';
+import baseFetch from './baseFetch';
 
 export const login = async (data: LoginFormData): Promise<LoginResponse> => {
-  try {
-    const response = await fetch('/api/auth/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    });
-
-    // 응답 데이터 파싱
-    const responseData = await response.json();
-
-    // HTTP 오류 처리
-    if (!response.ok) {
-      throw new Error(responseData.message || '로그인 요청이 실패했습니다.');
-    }
-
-    return responseData;
-  } catch (error) {
-    // 에러 처리
-    console.error('로그인 중 오류 발생:', error);
-    throw new Error(error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.');
-  }
+  const response = await baseFetch('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return response;
 };

--- a/lib/api/signUp.ts
+++ b/lib/api/signUp.ts
@@ -1,16 +1,13 @@
 import { API_BASE_URL } from '@/constants';
 import { SignupFormRequest, SignupResponse } from '../types/auth';
+import baseFetch from './baseFetch';
 
 export const signUp = async (data: SignupFormRequest): Promise<SignupResponse> => {
-  const response = await fetch(`${API_BASE_URL}/user`, {
+  const response = await baseFetch(`${API_BASE_URL}/user`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   });
 
-  if (!response.ok) {
-    const errorData = await response.json();
-    throw new Error(errorData.message);
-  }
-  return response.json();
+  return response;
 };

--- a/lib/utils/getDefaultErrorMessage.ts
+++ b/lib/utils/getDefaultErrorMessage.ts
@@ -1,0 +1,15 @@
+const getDefaultErrorMessage = (status: number): string => {
+  const statusMessages: Record<number, string> = {
+    400: '잘못된 요청입니다.',
+    401: '인증이 필요합니다.',
+    403: '접근 권한이 없습니다.',
+    404: '요청하신 리소스를 찾을 수 없습니다.',
+    500: '서버 오류가 발생했습니다.',
+    502: '게이트웨이 오류가 발생했습니다.',
+    503: '서비스를 일시적으로 사용할 수 없습니다.',
+  };
+
+  return statusMessages[status] || '알 수 없는 오류가 발생했습니다.';
+};
+
+export default getDefaultErrorMessage;


### PR DESCRIPTION
## ✅ 작업 내용
- 에러 처리를 baseFetch.ts 파일에 하였습니다.
- 노트편집페이지 fetch를 baseFetch로 바꾸었습니다.
- 로그인 및 회원가입에 적용해보았습니다.
- 에러 페이지를 404페이지와 동일하게 만들었습니다.
- 특정 요청url에 400or404가 뜨면 리다이렉션하게 만들었습니다.

- 혹시 안되는 거 있다면 말씀해주세요!!
- [간략한 설명](https://github.com/FESI-4-4/slid-todo/discussions/230)