### PR TITLE
[ not-found 리다이렉션 방법 변경 ] 

### DIFF
--- a/app/(nav)/goals/[goalId]/page.tsx
+++ b/app/(nav)/goals/[goalId]/page.tsx
@@ -2,18 +2,32 @@ import GoalTitleProgress from '@/components/common/GoalTitleWithProgress';
 import PageContainer from '@/components/common/pageLayout/PageContainer';
 import PageHeader from '@/components/common/pageLayout/PageHeader';
 import TodoItemsGoal from '@/components/goals/TodoItemsGoal';
+import baseFetch from '@/lib/api/baseFetch';
+import { Goal } from '@/lib/types/todo';
 import IconArrowRight from '@/public/icons/IconArrowRight';
 import IconNoteAll from '@/public/icons/IconNoteAll';
+import { cookies } from 'next/headers';
 import Link from 'next/link';
+import { notFound } from 'next/navigation';
 
-export default function GoalDetailPage({ params }: { params: { goalId: string } }) {
+export default async function GoalDetailPage({ params }: { params: { goalId: string } }) {
+  const accessToken = cookies().get('accessToken');
+  const initialGoal: Goal = await baseFetch(`${process.env.NEXT_PUBLIC_BASE_URL}/goals/${params.goalId}`, {
+    headers: { Authorization: `Bearer ${accessToken?.value}` },
+    cache: 'no-store',
+  });
+
+  if (!initialGoal) {
+    notFound();
+  }
+
   return (
     <PageContainer className={'max-w-[1200px] flex flex-col gap-4'}>
       <div className='hidden sm:block lg:block'>
         <PageHeader title='목표' />
       </div>
       <article className='flex-col'>
-        <GoalTitleProgress goalId={+params.goalId} />
+        <GoalTitleProgress goalId={+params.goalId} initialGoal={initialGoal} />
       </article>
       <div className='bg-blue-100 rounded-xl'>
         <Link href={`/notes/${params.goalId}`} className='flex px-6 py-4 gap-2 items-center'>

--- a/app/(nav)/notes/[goalId]/page.tsx
+++ b/app/(nav)/notes/[goalId]/page.tsx
@@ -1,12 +1,25 @@
 import PageContainer from '@/components/common/pageLayout/PageContainer';
 import PageHeader from '@/components/common/pageLayout/PageHeader';
 import NotesContent from '@/components/notes/NotesContent';
+import baseFetch from '@/lib/api/baseFetch';
+import { Goal } from '@/lib/types/todo';
+import { cookies } from 'next/headers';
+import { notFound } from 'next/navigation';
 
-export default function Notes({ params }: { params: { goalId: string } }) {
+export default async function Notes({ params }: { params: { goalId: string } }) {
+  const accessToken = cookies().get('accessToken');
+  const goalData: Goal = await baseFetch(`${process.env.NEXT_PUBLIC_BASE_URL}/goals/${params.goalId}`, {
+    headers: { Authorization: `Bearer ${accessToken?.value}` },
+    cache: 'no-store',
+  });
+  if (!goalData) {
+    notFound();
+  }
+
   return (
     <PageContainer>
       <PageHeader title='노트 모아보기' />
-      <NotesContent goalId={params.goalId} />
+      <NotesContent goalData={goalData} goalId={params.goalId} />
     </PageContainer>
   );
 }

--- a/app/(nav)/todos/[todoId]/note/[noteId]/page.tsx
+++ b/app/(nav)/todos/[todoId]/note/[noteId]/page.tsx
@@ -2,6 +2,7 @@ import { cookies } from 'next/headers';
 import NoteFormSections from '../../_view/NoteFormSections';
 import { SingleNote } from '@/lib/types/todo';
 import baseFetch from '@/lib/api/baseFetch';
+import { notFound } from 'next/navigation';
 
 export default async function Page({ params }: { params: { noteId: string } }) {
   const { noteId } = params;
@@ -11,6 +12,10 @@ export default async function Page({ params }: { params: { noteId: string } }) {
     headers: { Authorization: `Bearer ${accessToken?.value}` },
     cache: 'no-store',
   });
+
+  if (!response) {
+    notFound();
+  }
 
   const { title, content, linkUrl } = response;
   return (

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -2,9 +2,17 @@
 
 import Button from '@/components/common/ButtonSlid';
 import MainLogo from '@/public/images/MainLogo';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 export default function NotFound() {
+  const router = useRouter();
+
+  const handleGoHome = () => {
+    router.push('/');
+  };
+  const handleGoBack = () => {
+    router.back();
+  };
   return (
     <div className='min-h-screen bg-gradient-to-b from-blue-100 to-purple-100 flex flex-col items-center justify-center p-4'>
       <MainLogo className={`mb-[60px]`} />
@@ -19,11 +27,11 @@ export default function NotFound() {
         <h2 className='text-2xl font-semibold text-gray-800 mb-4'>앗! 페이지를 찾을 수 없어요</h2>
         <p className='text-gray-600 mb-8'>찾으시는 페이지가 사라졌거나 잘못된 주소를 입력하셨어요.</p>
         <div className='flex flex-col sm:flex-row justify-center gap-4'>
-          <Button onClick={() => window.history.back()} className='flex items-center justify-center'>
+          <Button onClick={handleGoBack} className='flex items-center justify-center'>
             뒤로 가기
           </Button>
-          <Button className='flex items-center justify-center' variant='outlined'>
-            <Link href='/'>홈으로 가기</Link>
+          <Button onClick={handleGoHome} className='flex items-center justify-center' variant='outlined'>
+            홈으로 가기
           </Button>
         </div>
       </div>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -2,9 +2,17 @@
 
 import Button from '@/components/common/ButtonSlid';
 import MainLogo from '@/public/images/MainLogo';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 export default function NotFound() {
+  const router = useRouter();
+
+  const handleGoHome = () => {
+    router.push('/');
+  };
+  const handleGoBack = () => {
+    router.back();
+  };
   return (
     <div className='min-h-screen bg-gradient-to-b from-blue-100 to-purple-100 flex flex-col items-center justify-center p-4'>
       <MainLogo className={`mb-[60px]`} />
@@ -19,11 +27,11 @@ export default function NotFound() {
         <h2 className='text-2xl font-semibold text-gray-800 mb-4'>앗! 페이지를 찾을 수 없어요</h2>
         <p className='text-gray-600 mb-8'>찾으시는 페이지가 사라졌거나 잘못된 주소를 입력하셨어요.</p>
         <div className='flex flex-col sm:flex-row justify-center gap-4'>
-          <Button onClick={() => window.history.back()} className='flex items-center justify-center'>
+          <Button onClick={handleGoBack} className='flex items-center justify-center'>
             뒤로 가기
           </Button>
-          <Button className='flex items-center justify-center' variant='outlined'>
-            <Link href='/'>홈으로 가기</Link>
+          <Button onClick={handleGoHome} className='flex items-center justify-center' variant='outlined'>
+            홈으로 가기
           </Button>
         </div>
       </div>

--- a/components/common/GoalTitleWithProgress.tsx
+++ b/components/common/GoalTitleWithProgress.tsx
@@ -11,9 +11,10 @@ import { useUpdateGoalMutation } from '@/lib/hooks/useUpdateGoalMutation';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import InputSlid from './InputSlid';
+import { Goal } from '@/lib/types/todo';
 
-const GoalTitleWithProgress = ({ goalId }: { goalId: number }) => {
-  const { data: goal } = useGoalQuery(goalId);
+const GoalTitleWithProgress = ({ goalId, initialGoal }: { goalId: number; initialGoal: Goal }) => {
+  const { data: goal } = useGoalQuery(goalId, initialGoal);
   const progress = useTodoProgressQuery(goalId).data?.progress || 0;
   const deleteGoal = useDeleteGoalMutation();
   const updateGoal = useUpdateGoalMutation();

--- a/components/notes/NotesContent.tsx
+++ b/components/notes/NotesContent.tsx
@@ -2,35 +2,19 @@
 
 import { useIntersectionObserver } from '@/lib/hooks/useIntersectionObserver';
 import { useNotesInfiniteQuery } from '@/lib/hooks/useNotesInfiniteQuery';
-import { useEffect, useState } from 'react';
 import NoteGoalTitle from './NoteGoalTitle';
 import NotesList from './NotesList';
-import baseFetch from '@/lib/api/baseFetch';
-import { HttpError } from '@/lib/api/errorHandlers';
+import { Goal } from '@/lib/types/todo';
 
 interface NotesContentProps {
   goalId: string;
+  goalData: Goal;
 }
 
-const NotesContent: React.FC<NotesContentProps> = ({ goalId }) => {
-  const [goalTitle, setGoalTitle] = useState('');
+const NotesContent: React.FC<NotesContentProps> = ({ goalId, goalData }) => {
   const { data, fetchNextPage, hasNextPage, isFetching } = useNotesInfiniteQuery({
     goalId: Number(goalId),
   });
-  useEffect(() => {
-    const getGoalTitle = async () => {
-      try {
-        const goalData = await baseFetch(`/4-4-dev/goals/${goalId}`);
-        setGoalTitle(goalData.title);
-      } catch (error) {
-        if (error instanceof HttpError) {
-          console.error('Error fetching goal title:', error.message);
-        }
-      }
-    };
-
-    getGoalTitle();
-  }, [goalId]);
 
   const loadMoreRef = useIntersectionObserver({
     onIntersect: fetchNextPage,
@@ -44,7 +28,7 @@ const NotesContent: React.FC<NotesContentProps> = ({ goalId }) => {
 
   return (
     <>
-      <NoteGoalTitle goalTitle={goalTitle} link={`/goals/${goalId}`} />
+      <NoteGoalTitle goalTitle={goalData.title} link={`/goals/${goalId}`} />
       <NotesList notes={validNotes} isFetching={isFetching} />
       <div ref={loadMoreRef} className='h-10 flex items-center justify-center'>
         {isFetching && <div>불러오는 중...</div>}

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -32,5 +32,3 @@ export const AUTH_ERROR_MESSAGES = {
   EMAIL_VALIDATION_FAILED: '이메일 검증에 실패했습니다.',
   SERVER_ERROR: '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
 };
-
-export const REDIRECT_ON_404_PATHS = ['/4-4-dev/goals/'];

--- a/lib/api/errorHandlers.ts
+++ b/lib/api/errorHandlers.ts
@@ -1,9 +1,4 @@
-import { REDIRECT_ON_404_PATHS } from '@/constants';
 import getDefaultErrorMessage from '../utils/getDefaultErrorMessage';
-
-const shouldRedirectOn404 = (url: string) => {
-  return REDIRECT_ON_404_PATHS.some((path) => url.includes(path));
-};
 
 export class HttpError extends Error {
   constructor(public status: number, message: string, public url: string) {
@@ -20,26 +15,12 @@ export const handleHttpError = (data: Data, status: number, url: string) => {
   // slid 서버의 경우 { message: string } 형태로 에러 메시지를 전달하기 때문에 이와 같이 정의
 
   const message = data.message ?? getDefaultErrorMessage(status);
-  if (status === 400) {
-    handle404Error(url);
-  }
-
-  if (status === 404) {
-    handle404Error(url);
-  }
 
   if (status === 500) {
     handleServerError(url);
   }
 
   throw new HttpError(status, message, url);
-};
-
-const handle404Error = (url: string) => {
-  if (shouldRedirectOn404(url)) {
-    window.location.href = '/404';
-    return;
-  }
 };
 
 const handleServerError = (url: string) => {

--- a/lib/hooks/useGoalQuery.ts
+++ b/lib/hooks/useGoalQuery.ts
@@ -2,10 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import { Goal } from '../types/todo';
 import baseFetch from '../api/baseFetch';
 
-const useGoalQuery = (goalId: number) => {
+const useGoalQuery = (goalId: number, initialData?: Goal) => {
   return useQuery<Goal>({
     queryKey: ['goal', goalId],
     queryFn: () => baseFetch(`/4-4-dev/goals/${goalId.toString()}`),
+    initialData: initialData,
   });
 };
 export default useGoalQuery;


### PR DESCRIPTION
close #232
close #233 

## ✅ 작업 내용
- ```import { notFound } from 'next/navigation';```를 사용해서 서버 사이드 랜더링이 일어나는 시점에 리다이렉션을 하게 바꾸었습니다.
- 데이터 값이 없을 때 리다이렉션이 필요한 페이지에서 notFound 함수를 사용하기 위해 초기값을 SSR하는 방법으로 바꿨습니다( 노트 모아보기 페이지의 목표, 목표 페이지의 목표 초기값)
- handleHttpError 함수에서 404 리다이렉션 관련 함수를 모두 삭제했습니다(notFound를 사용할것이므로 더이상 필요가 없습니다).
- 404페이지 버튼 클릭이 잘되도록 수정하였습니다.
- [lib/hooks/useGoalQuery.ts](https://github.com/FESI-4-4/slid-todo/compare/fix/232?expand=1#diff-1eb22c800762516d3dab98b78278ba67cfb20afa0cf734c75e344254203e491c) 초기값을 넣어줄 수 있게 변경하였습니다.
## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항

## ✍ 궁금한 것
