### PR TITLE
[ 대시보드 ] 반응형 디자인 개선

### DIFF
--- a/app/(nav)/dashboard/page.tsx
+++ b/app/(nav)/dashboard/page.tsx
@@ -11,7 +11,7 @@ export default function DashboardPage() {
       <div className='hidden sm:block lg:block'>
         <PageHeader title='대시보드' />
       </div>
-      <div className='w-full flex flex-col sm:flex-row lg:flex-row gap-2 sm:gap-6 lg:gap-[27px]'>
+      <div className='w-full flex flex-col sm:flex-row lg:flex-row gap-2 sm:gap-6'>
         <RecentTodo />
         <Progress />
       </div>

--- a/components/dashboard/Progress.tsx
+++ b/components/dashboard/Progress.tsx
@@ -10,7 +10,7 @@ const Progress = () => {
   const { data } = useTodoProgressQuery();
   return (
     <section className='relative flex flex-1 min-w-0 min-h-[250px] bg-blue-500 rounded-xl'>
-      <div className='flex-col px-6 pt-4'>
+      <div className='flex-col pl-6 pt-4'>
         <div className='w-10 h-10 bg-slate-900 rounded-[15px] grid place-content-center'>
           <IconProgress />
         </div>

--- a/components/dashboard/TodoItemsDashboard.tsx
+++ b/components/dashboard/TodoItemsDashboard.tsx
@@ -28,7 +28,7 @@ const TodoItemsDashboard = ({ goalId }: { goalId: number }) => {
   // todo, done 중 하나라도 hasNextPage가 있으면 표시.
   const isMoreButtonVisible = useMemo(() => queries.some((query) => query.hasNextPage), [queries]);
 
-  const containerClass = 'w-full h-auto flex flex-col min-h-[184px] gap-3 rounded-lg';
+  const containerClass = 'w-full h-auto flex flex-col flex-1 min-h-[184px] gap-3 rounded-lg basis-0';
   const contentClass = (isEmpty: boolean) =>
     clsx(
       'w-full flex',
@@ -66,7 +66,7 @@ const TodoItemsDashboard = ({ goalId }: { goalId: number }) => {
 
   return (
     <div className='flex flex-col w-full gap-4'>
-      <div className='w-full h-auto flex flex-col sm:flex-col lg:flex-row gap-6'>{todoLists}</div>
+      <div className='w-full h-auto grid grid-cols-1 lg:grid-cols-2 gap-6'>{todoLists}</div>
       {isMoreButtonVisible && (
         <div className='w-full flex justify-center'>
           <Button


### PR DESCRIPTION
close #236 

## ✅ 작업 내용
목표별 할일 안 todo와 done 상자가 동등하게 줄어들게 하였고 화면이 줄어듦에따라 같이 줆어들게 만들었습니다.




## 📸 스크린샷 / GIF / Link
### Before


https://github.com/user-attachments/assets/03f05776-7efc-48b3-a2fc-be9addb594f1

### After

https://github.com/user-attachments/assets/f49dabf1-2ede-4334-9020-a1d0ac4b932b
## 📌 이슈 사항
도넛이 lg크기상 제일 작아졌을 떄 튀어나오긴 하는데 도넛이 아닌 다른 대안적 애니메이션이 나온다면 도넛 자체가 사라질 거 같아 일단은 그냥 두었습니다

## ✍ 궁금한 것
