### PR TITLE
[ 목표 ] 목표 관련 애니메이션 추가

### DIFF
--- a/app/(nav)/goals/[goalId]/page.tsx
+++ b/app/(nav)/goals/[goalId]/page.tsx
@@ -29,7 +29,7 @@ export default async function GoalDetailPage({ params }: { params: { goalId: str
       <article className='flex-col'>
         <GoalTitleProgress goalId={+params.goalId} initialGoal={initialGoal} />
       </article>
-      <div className='bg-blue-100 rounded-xl'>
+      <div className='bg-blue-100 rounded-xl hover:shadow-lg transition-all duration-200'>
         <Link href={`/notes/${params.goalId}`} className='flex px-6 py-4 gap-2 items-center'>
           <div className='flex-shrink-0'>
             <IconNoteAll />

--- a/components/common/ProgressBar.tsx
+++ b/components/common/ProgressBar.tsx
@@ -6,7 +6,10 @@ const ProgressBar = ({ percentage, className }: { percentage: number; className?
   return (
     <div className={progressBarClass}>
       <div className='relative w-full bg-slate-100 rounded-full h-1'>
-        <div className='absolute top-0 left-0 bg-slate-900 h-1 rounded-full' style={{ width: `${percentage}%` }}></div>
+        <div
+          className='absolute top-0 left-0 bg-slate-900 h-1 rounded-full transition-all ease-in-out duration-1000'
+          style={{ width: `${percentage}%` }}
+        ></div>
       </div>
       <div className='flex ml-auto text-xs font-semibold'>
         <span>{percentage}%</span>

--- a/components/common/ProgressBar.tsx
+++ b/components/common/ProgressBar.tsx
@@ -1,8 +1,19 @@
+'use client';
 import clsx from 'clsx';
+import { useEffect, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 
-const ProgressBar = ({ percentage, className }: { percentage: number; className?: string }) => {
+const ProgressBar = ({ percentage: initialPercentage, className }: { percentage: number; className?: string }) => {
   const progressBarClass = twMerge(clsx('flex items-center gap-2  py-1 w-full bg-white rounded-full', className));
+  const [percentage, setPercentage] = useState(0);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setPercentage(initialPercentage);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [initialPercentage]);
+
   return (
     <div className={progressBarClass}>
       <div className='relative w-full bg-slate-100 rounded-full h-1'>


### PR DESCRIPTION
## ✅ 작업 내용
목표와 관련된 애니메이션을 추가했습니다.

- 대시보드와 목표 상세 페이지의 각 목표 별 Progress bar에 완료 퍼센트 부분이 채워지면서 나타나는 애니메이션을 적용했습니다.
- 요구사항은 목표 상세 페이지의 각 요소 hover시 shadow 추가 및 애니메이션이었지만 유효하게 클릭 가능한 요소가 노트 모아보기 뿐이라 여기에만 적용했습니다.
  - 노트 모아보기 페이지와 동일하게 shadow-lg를 적용했습니다.

## 📸 스크린샷 / GIF / Link

대시보드 (gif)

![Kapture 2024-11-07 at 17 12 09](https://github.com/user-attachments/assets/ade1cfe0-0420-4d69-939d-8d13fab69972)


목표상세페이지 (gif)

![Kapture 2024-11-07 at 17 13 38](https://github.com/user-attachments/assets/eadab22d-d0d1-4452-8a77-365f073eea89)

목표 상세 페이지 노트 모아보기 카드 hover shadow (image)

![image](https://github.com/user-attachments/assets/4c1b2e4b-7684-48d3-9ca6-d3098ad02d8d)


