### PR TITLE
[ NAV ] style 수정 및 tablet 닫기 버튼 제거

### DIFF
--- a/components/nav/NavBarTablet.tsx
+++ b/components/nav/NavBarTablet.tsx
@@ -17,6 +17,7 @@ import { SheetContent, SheetProvider, SheetTrigger } from '../common/Sheet';
 const NavBarTablet = () => {
   const [isSheetNavOpen, setIsSheetNavOpen] = useState(false); // 모바일, 태블릿 nav 왼쪽 시트 열림 여부
   const [isTodoModalOpen, setIsTodoModalOpen] = useState(false); // 할 일 모달 열림 여부
+
   const handleNavButtonClick = () => {
     setIsSheetNavOpen(!isSheetNavOpen);
   };
@@ -29,18 +30,10 @@ const NavBarTablet = () => {
     <>
       <SheetProvider isOpen={isSheetNavOpen} onChangeIsOpen={setIsSheetNavOpen}>
         <SheetTrigger>
-          <div
-            className={`${
-              isSheetNavOpen
-                ? 'flex flex-row justify-between items-center p-4'
-                : 'hidden sm:flex lg:flex flex-col justify-center items-center space-y-4 p-4'
-            }`}
-          >
-            <Link href='/dashboard' className={`${isSheetNavOpen ? 'py-2 px-[5px]' : 'flex items-center'}`}>
-              {isSheetNavOpen ? <ImageLogoWithText /> : <ImageLogo />}
-            </Link>
+          <div className={'flex flex-col justify-center items-center space-y-4 p-4'}>
+            <Link href='/dashboard'>{<ImageLogo />}</Link>
             <div
-              className='flex justify-center items-center sm:block w-6 h-6 p-1 bg-white hover:bg-slate-100 active:bg-slate-300 rounded-lg border-[1.5px] border-slate-400'
+              className='grid place-content-center hover:cursor-pointer w-6 h-6 p-1 bg-white hover:bg-slate-100 active:bg-slate-300 rounded-lg border-[1.5px] border-slate-400'
               onClick={handleNavButtonClick}
             >
               <IconFold isFold={!isSheetNavOpen} />
@@ -52,7 +45,7 @@ const NavBarTablet = () => {
             className={twMerge(
               clsx(
                 'flex flex-col border-r-[1px] h-screen transition-all ease-out duration-300',
-                isSheetNavOpen ? 'flex-shrink-0 sm:w-[280px] divide-slate-200' : 'p-4 px-[14px] items-center'
+                isSheetNavOpen ? 'flex-shrink-0 sm:w-[280px] divide-slate-200' : 'opacity-0 w-0 h-0'
               )
             )}
           >
@@ -61,19 +54,12 @@ const NavBarTablet = () => {
               className={`${
                 isSheetNavOpen
                   ? 'flex flex-row justify-between items-center p-4'
-                  : 'hidden sm:flex lg:flex flex-col justify-center items-center space-y-4'
+                  : 'opacity-0 w-0 h-0 sm:flex lg:flex flex-col justify-center items-center space-y-4'
               }`}
             >
-              <Link href='/dashboard' className={`${isSheetNavOpen ? 'py-2 px-[5px]' : 'flex items-center'}`}>
-                {isSheetNavOpen ? <ImageLogoWithText /> : <ImageLogo />}
+              <Link href='/dashboard' className={`${isSheetNavOpen ? 'py-2 px-[5px]' : 'hidden'}`}>
+                <ImageLogoWithText />
               </Link>
-              {/* 데스크탑에서만 작동하는 열기 버튼 */}
-              <div
-                className='hidden sm:grid lg:grid place-content-center hover:cursor-pointer w-6 h-6 p-1 bg-white hover:bg-slate-100 active:bg-slate-300 rounded-lg border-[1.5px] border-slate-400'
-                onClick={handleNavButtonClick}
-              >
-                <IconFold isFold={!isSheetNavOpen} />
-              </div>
             </div>
             {/* 메뉴 영역(접힌 nav에서는 안보이는 영역) */}
             <div className={isSheetNavOpen ? '' : 'opacity-0 w-0 h-0'}>

--- a/components/nav/NavBarTablet.tsx
+++ b/components/nav/NavBarTablet.tsx
@@ -67,8 +67,9 @@ const NavBarTablet = () => {
               <Link href='/dashboard' className={`${isSheetNavOpen ? 'py-2 px-[5px]' : 'flex items-center'}`}>
                 {isSheetNavOpen ? <ImageLogoWithText /> : <ImageLogo />}
               </Link>
+              {/* 데스크탑에서만 작동하는 열기 버튼 */}
               <div
-                className='flex justify-center items-center sm:block w-6 h-6 p-1 bg-white hover:bg-slate-100 active:bg-slate-300 rounded-lg border-[1.5px] border-slate-400'
+                className='hidden sm:grid lg:grid place-content-center hover:cursor-pointer w-6 h-6 p-1 bg-white hover:bg-slate-100 active:bg-slate-300 rounded-lg border-[1.5px] border-slate-400'
                 onClick={handleNavButtonClick}
               >
                 <IconFold isFold={!isSheetNavOpen} />

--- a/components/nav/NavBarTemp.tsx
+++ b/components/nav/NavBarTemp.tsx
@@ -27,7 +27,7 @@ const NavBarTemp = () => {
   const [currentPageLabel, setCurrentPageLabel] = useState('대시보드');
   const pathname = usePathname();
   const hasMounted = useRef(false);
-  const [isFullyOpen, setIsFullyOpen] = useState(false);
+  const [isFullyOpen, setIsFullyOpen] = useState(true);
 
   const handleTodoModalOpen = () => {
     setIsTodoModalOpen(true);
@@ -105,9 +105,8 @@ const NavBarTemp = () => {
           clsx(
             'flex border-r-[1px]',
             isOpen
-              ? 'h-screen flex-col flex-shrink-0 sm:w-[280px] divide-slate-200'
-              : 'flex-row sm:flex-col lg:flex-col p-4 px-[14px] items-center sm:w-16 lg:w-16',
-            isFullyOpen ? 'transition-all ease-in-out duration-1000' : 'transition-all ease-in-out duration-1000'
+              ? 'h-screen flex-col flex-shrink-0 sm:w-[280px] divide-slate-200 transition-all ease-in-out duration-500'
+              : 'flex-row sm:flex-col lg:flex-col p-4 px-[14px] items-center sm:w-16 lg:w-16'
           )
         )}
         style={{
@@ -155,7 +154,7 @@ const NavBarTemp = () => {
           <Link
             href='/dashboard'
             className={clsx(
-              'flex items-center transition-opacity duration-1000',
+              'flex items-center transition-opacity duration-500',
               isFullyOpen ? 'opacity-100' : 'opacity-0',
               isOpen ? 'visible' : 'invisible'
             )}
@@ -167,7 +166,7 @@ const NavBarTemp = () => {
           <div
             className={clsx(
               'block sm:hidden lg:hidden',
-              'transition-opacity duration-1000',
+              'transition-opacity duration-500',
               isFullyOpen ? 'opacity-100' : 'opacity-0',
               isOpen ? 'visible' : 'invisible'
             )}
@@ -183,7 +182,7 @@ const NavBarTemp = () => {
           <div
             className={clsx(
               'hidden sm:hidden lg:block',
-              'transition-opacity duration-1000',
+              'transition-opacity duration-500',
               isFullyOpen ? 'opacity-100' : 'opacity-0',
               isOpen ? 'visible' : 'invisible'
             )}
@@ -199,7 +198,7 @@ const NavBarTemp = () => {
         {/* 메뉴 영역(접힌 nav에서는 안보이는 영역) */}
         <div
           className={clsx(
-            'transition-opacity duration-1000',
+            'transition-opacity duration-500',
             isFullyOpen ? 'opacity-100' : 'opacity-0',
             isOpen ? 'visible' : 'invisible w-0 h-0 lg:h-full'
           )}

--- a/components/nav/NavBarTemp.tsx
+++ b/components/nav/NavBarTemp.tsx
@@ -137,7 +137,7 @@ const NavBarTemp = () => {
 
           {/* 데스크탑에서만 작동하는 열기 버튼 */}
           <div
-            className='hidden sm:grid lg:grid  place-content-center w-6 h-6 p-1 bg-white hover:bg-slate-100 active:bg-slate-300 rounded-lg border-[1.5px] border-slate-400'
+            className='hidden sm:grid lg:grid place-content-center hover:cursor-pointer w-6 h-6 p-1 bg-white hover:bg-slate-100 active:bg-slate-300 rounded-lg border-[1.5px] border-slate-400'
             onClick={() => handleNavButtonClick('desktop')}
           >
             <IconFold isFold={true} />


### PR DESCRIPTION
## ✅ 작업 내용
- 태블릿 nav가 열린 상태에서 닫기 버튼을 제거해 기존 디자인대로 외부 영역을 클릭해 시트를 닫도록 수정했습니다.
- 태블릿 nav가 닫힌 상태에서 버튼 내부 아이콘을 가운데 정렬했습니다.
- 태블릿 nav가 닫힌 상태에서 hover:cursor-point를 추가해 호버시 클릭 할 수 있는 손 모양 커서가 되도록 변경했습니다.
- 데스크탑과 모바일에서 duration 시간을 500으로 줄였습니다.

![image](https://github.com/user-attachments/assets/4ff27940-4239-4a76-b4e0-b8772075f8da)

close #248 