### PR TITLE
[ 할 일 생성 & 수정 ] 엔터키 & 모달 필수요소 표시

### DIFF
--- a/components/common/Modal.tsx
+++ b/components/common/Modal.tsx
@@ -133,7 +133,7 @@ const ModalClose = memo(
       }
 
       return (
-        <button onClick={handleClose} {...props} ref={ref}>
+        <button type='button' onClick={handleClose} {...props} ref={ref}>
           {children ? children : <IconModalClose />}
         </button>
       );

--- a/components/modal/todoModal/TodoAddModal.tsx
+++ b/components/modal/todoModal/TodoAddModal.tsx
@@ -59,6 +59,7 @@ const Content = ({ goalId }: { goalId?: number }) => {
           label='제목'
           placeholder='할 일의 제목을 적어주세요'
           error={errors.title?.message}
+          labelClassName="relative after:content-['*'] after:ml-0.5 after:text-red-500"
           {...register('title')}
         />
         <InputSlid

--- a/components/modal/todoModal/TodoEditModal.tsx
+++ b/components/modal/todoModal/TodoEditModal.tsx
@@ -63,6 +63,7 @@ const Content = ({ data }: { data: Todo }) => {
           label='제목'
           placeholder='할 일의 제목을 적어주세요'
           error={errors.title?.message}
+          labelClassName="relative after:content-['*'] after:ml-0.5 after:text-red-500"
           {...register('title')}
         />
         <InputSlid


### PR DESCRIPTION
close #252 
## ✅ 작업 내용
- 모달 안에서 폼을 사용시 엔터키를 누르면 폼의 버튼이 누르는게 아니라 ModalClose가 작동하는 것을 확인
- ModalClose의 button에 타입을 주어 폼과 무관하게 수정
- 할 일 추가하기, 수정하기 모달에 필수 폼인 타이틀에 '*' 표시 추가 
- 가상요소 ```::after``` 사용
## 📸 스크린샷 / GIF / Link
![image](https://github.com/user-attachments/assets/93636bd0-8787-42f9-93f7-c54db4ac38fb)




## 📌 이슈 사항

## ✍ 궁금한 것
