### PR TITLE
[ 노트 ] 임베드 안 되는 링크 예외 처리

### DIFF
--- a/app/(nav)/todos/[todoId]/_view/NoteFormSections.tsx
+++ b/app/(nav)/todos/[todoId]/_view/NoteFormSections.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import IconModalClose from '@/public/icons/IconModalClose';
 import NoteFormSection, { SavedNote } from './NoteFormSection';
 import { useParams } from 'next/navigation';
+import Link from 'next/link';
 
 type NoteFormSectionsProps = {
   title?: string;
@@ -27,6 +28,7 @@ const NoteFormSections = ({
   const [content, setContent] = useState(initContent);
   const [openSavedToast, setOpenSavedToast] = useState(false);
   const [savedToast, setSavedToast] = useState(false);
+  const [linkUrlEmbeddable, setLinkUrlEmbeddable] = useState(true);
 
   const handleChangeOpenSavedToast = (status: boolean) => setOpenSavedToast(status);
   const handleChangeSavedToast = (status: boolean) => setSavedToast(status);
@@ -57,6 +59,17 @@ const NoteFormSections = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    (async () => {
+      try {
+        await fetch(linkUrl, { method: 'HEAD' });
+        setLinkUrlEmbeddable(true);
+      } catch {
+        setLinkUrlEmbeddable(false);
+      }
+    })();
+  }, [linkUrl]);
+
   return (
     <>
       {linkUrl && isEmbedOpen && (
@@ -66,8 +79,20 @@ const NoteFormSections = ({
               <IconModalClose />
             </button>
           </div>
-          <div className='h-full pt-10 bg-blue-50'>
-            <iframe src={linkUrl} className='h-full w-full' />
+          <div className='h-full pt-10 bg-blue-50 flex flex-col justify-center items-center'>
+            {linkUrlEmbeddable ? (
+              <iframe src={linkUrl} className='h-full w-full' />
+            ) : (
+              <>
+                <p>임베드할 수 없는 링크입니다.</p>
+                <p>
+                  <Link href={linkUrl} target='_blank' className='hover:underline'>
+                    {linkUrl}
+                  </Link>
+                  으로 이동
+                </p>
+              </>
+            )}
           </div>
         </section>
       )}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->

<!-- ex) [Home] 대시보드에서 ~~ 구현 -->

## ✅ 작업 내용
### 임베드 안 되는 링크 예외 처리
컴포넌트 마운트 후 임베드링크가 업데이트 될 때마다 HEAD 요청을 보내고
그 요청에서 fetch 에러가 발생하면 iframe 대신 링크로 이동할 수 있도록 UI를 구현했습니다. 

## 📸 스크린샷 / GIF / Link
![image](https://github.com/user-attachments/assets/e1405c8e-304c-486c-b5db-43b6835efffe)

## 📌 이슈 사항
closes #254 

## ✍ 궁금한 것
