### PR TITLE
[ 로그인 ] 리다이렉션 방식 변경

### DIFF
--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -32,7 +32,7 @@ const LoginForm: React.FC = () => {
         title: '로그인 성공',
         variant: 'success',
       });
-      router.replace('/dashboard');
+      router.refresh();
     } catch (error) {
       if (error instanceof HttpError) {
         const { field, message } = parseAuthError(error);

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -9,6 +9,8 @@ import { login } from '@/lib/api/login';
 import { setUserToStorage } from '@/lib/utils/auth';
 import { parseAuthError } from '@/lib/utils/parseError';
 import { HttpError } from '@/lib/api/errorHandlers';
+import { useRouter } from 'next/navigation';
+import useToast from './common/toast/useToast';
 
 const LoginForm: React.FC = () => {
   const {
@@ -20,12 +22,17 @@ const LoginForm: React.FC = () => {
     resolver: zodResolver(loginSchema),
     mode: 'onBlur',
   });
-
+  const router = useRouter();
+  const toast = useToast();
   const onSubmit: SubmitHandler<LoginFormData> = async (data) => {
     try {
       const response = await login(data);
       setUserToStorage(response.user);
-      window.location.href = '/dashboard';
+      toast.toast({
+        title: '로그인 성공',
+        variant: 'success',
+      });
+      router.replace('/dashboard');
     } catch (error) {
       if (error instanceof HttpError) {
         const { field, message } = parseAuthError(error);


### PR DESCRIPTION
close #266 

## ✅ 작업 내용  
- window.location을 사용하면 루트 layout에 있는 토스트라 할지라도 아예 초기화 돼버려서 리다이렉션이 일어난 직후 바로 닫혀 버리는 문제가 있었습니다.
- 기존 useRouter의 push는 캐싱되어 로그인을 했음에도 뒤로가기가 되어 문제가 되었습니다.
- replace를 사용했을 때는 로그인 당시 히스토리가 리다이렉션 되는 dashboard로 대체가 되어 뒤로가기 눌렀을 때 로그인 페이지가 나오지 않으나, 만약 직전 회원가입 페이지를 들렀다면 회원가입 페이지가 캐싱되어 리다이렉션되지 않고 나타나버립니다.
- 로그인과 회원가입 페이지의 캐싱 기능을 꺼보려고 했지만 잘 되지 않았습니다.
결론
- useRouter의 refresh기능을 사용해서 캐싱을 초기화하여 뒤로가기 버튼을 눌러도 다시 한번 미들에어로 들어가게 하여 리다이렉션을 시켰습니다
## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항

## ✍ 궁금한 것
