### PR TITLE
[ 목표 ] 목표 삭제시 목표가 3개밖에 안나오는 오류 수정

### DIFF
--- a/lib/hooks/useInfiniteGoalsQuery.ts
+++ b/lib/hooks/useInfiniteGoalsQuery.ts
@@ -4,7 +4,7 @@ import baseFetch from '../api/baseFetch';
 
 const useInfiniteGoalsQuery = (size: number = 3) => {
   return useInfiniteQuery<Goals>({
-    queryKey: ['goals'],
+    queryKey: ['goals', size],
     queryFn: ({ pageParam = null }) => {
       const params = new URLSearchParams({
         ...(pageParam !== null && { cursor: String(pageParam) }),

--- a/lib/hooks/useUpdateGoalMutation.ts
+++ b/lib/hooks/useUpdateGoalMutation.ts
@@ -23,7 +23,8 @@ export const useUpdateGoalMutation = () => {
         title: '목표가 수정되었습니다.',
         variant: 'success',
       });
-      queryClient.invalidateQueries({ queryKey: ['goals'] });
+      queryClient.invalidateQueries({ queryKey: ['goals'], refetchType: 'all' });
+
     },
     onError: (error) => {
       toast.toast({


### PR DESCRIPTION
## ✅ 작업 내용

목표 삭제 후 nav에 목표가 3개밖에 안나오던 오류를 수정했습니다.
목표 수정 후 대시보드 진입 시 수정된 내용이 반영되지 않던 오류를 수정했습니다.

close #261 
