### PR TITLE
[ NAV ] 목표 호버시 케밥 아이콘으로 빠른 수정삭제 기능 추가

### DIFF
--- a/app/(nav)/goals/[goalId]/page.tsx
+++ b/app/(nav)/goals/[goalId]/page.tsx
@@ -1,4 +1,4 @@
-import GoalTitleProgress from '@/components/common/GoalTitleWithProgress';
+import GoalTitleProgress from '@/components/goals/GoalTitleWithProgress';
 import PageContainer from '@/components/common/pageLayout/PageContainer';
 import PageHeader from '@/components/common/pageLayout/PageHeader';
 import TodoItemsGoal from '@/components/goals/TodoItemsGoal';

--- a/components/common/DropdownMenu.tsx
+++ b/components/common/DropdownMenu.tsx
@@ -9,6 +9,7 @@ interface DropdownProps {
   text?: string;
   dropdownList: string[];
   dropdownAlign?: 'center' | 'right';
+  dropdownPosition?: 'top' | 'bottom';
   onItemClick: (item: string) => void;
   className?: string;
   iconClassName?: string;
@@ -23,6 +24,7 @@ const DropdownMenu = ({
   text,
   dropdownList,
   dropdownAlign = 'right',
+  dropdownPosition = 'bottom',
   onItemClick,
   className,
   iconClassName,
@@ -52,6 +54,17 @@ const DropdownMenu = ({
   const closeDropdown = () => setDropdownOpen(false);
 
   useEffect(() => {
+    if (isDropdownOpen && dropdownRef.current) {
+      // 드롭다운이 열릴 때 자동으로 스크롤해 메뉴가 화면에 모두 보이도록
+      dropdownRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+        inline: 'nearest',
+      });
+    }
+  }, [isDropdownOpen]);
+
+  useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       const target = event.target as Node;
       if (
@@ -74,7 +87,8 @@ const DropdownMenu = ({
   const dropdownClassNames = twMerge(
     clsx(
       'z-10 absolute bg-white rounded-xl text-slate-700 max-h-64 sm:max-h-32 lg:max-h-32 overflow-y-auto',
-      dropdownAlign === 'right' ? 'right-0 shadow-[4px_4px_10px_-2px_rgba(0,0,0,0.05)]' : 'w-full shadow-lg left-0'
+      dropdownAlign === 'right' ? 'right-0 shadow-[4px_4px_10px_-2px_rgba(0,0,0,0.05)]' : 'w-full shadow-lg left-0',
+      dropdownPosition === 'top' ? 'bottom-full mb-2' : 'top-full mt-2'
     )
   );
 

--- a/components/common/DropdownMenu.tsx
+++ b/components/common/DropdownMenu.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useState, useEffect, useRef, ComponentType, SVGProps } from 'react';
 import clsx from 'clsx';
+import { twMerge } from 'tailwind-merge';
 
 interface DropdownProps {
   icon?: ComponentType<SVGProps<SVGSVGElement>>;
@@ -66,24 +67,31 @@ const DropdownMenu = ({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  const dropdownClassNames = clsx(
-    'z-10 absolute mt-2 bg-white rounded-xl text-slate-700 max-h-64 sm:max-h-32 lg:max-h-32 overflow-y-auto',
-    dropdownAlign === 'right' ? 'right-0 shadow-[4px_4px_10px_-2px_rgba(0,0,0,0.05)]' : 'w-full shadow-lg left-0'
+  const baseClassNames = twMerge(
+    clsx('flex-col justify-center items-center relative inline-block text-nowrap space-y-2', className)
   );
 
-  const dropdownMenuListClassNames = clsx(
-    'flex flex-col text-nowrap text-sm sm:text-lg lg:text-lg justify-center items-center text-center',
-    dropdownListClassName
+  const dropdownClassNames = twMerge(
+    clsx(
+      'z-10 absolute bg-white rounded-xl text-slate-700 max-h-64 sm:max-h-32 lg:max-h-32 overflow-y-auto',
+      dropdownAlign === 'right' ? 'right-0 shadow-[4px_4px_10px_-2px_rgba(0,0,0,0.05)]' : 'w-full shadow-lg left-0'
+    )
   );
 
-  const dropdownMenuItemClassNames = clsx(
-    'w-full flex max-h-[100px] overflow-y-auto',
-    'px-4 pt-2 pb-[6px] hover:bg-gray-100 cursor-pointer first:rounded-t-xl last:rounded-b-xl',
-    dropdownItemClassName
+  const dropdownMenuListClassNames = twMerge(
+    clsx('flex flex-col text-nowrap text-lg justify-center items-center text-center', dropdownListClassName)
+  );
+
+  const dropdownMenuItemClassNames = twMerge(
+    clsx(
+      'w-full flex max-h-[100px] overflow-y-auto',
+      'px-4 pt-2 pb-[6px] hover:bg-gray-100 cursor-pointer first:rounded-t-xl last:rounded-b-xl',
+      dropdownItemClassName
+    )
   );
 
   return (
-    <div className={`flex-col justify-center items-center relative inline-block text-nowrap ${className}`}>
+    <div className={baseClassNames}>
       <button
         ref={iconButtonRef}
         type='button'

--- a/components/common/todoItem/TodoIcon.tsx
+++ b/components/common/todoItem/TodoIcon.tsx
@@ -32,7 +32,7 @@ const TodoIcon: React.FC<TodoIconProps> = ({ data }) => {
     deleteTodo.mutate({ todoId: data.id });
   };
 
-  const handleDropdaownMenuClick = (item: string) => {
+  const handleDropdownMenuClick = (item: string) => {
     if (isMobile()) return;
     if (item === '수정하기') {
       onChangeIsOpen(true);
@@ -101,7 +101,7 @@ const TodoIcon: React.FC<TodoIconProps> = ({ data }) => {
           <DropdownMenu
             icon={IconKebabWithCircle}
             dropdownList={['수정하기', '삭제하기']}
-            onItemClick={handleDropdaownMenuClick}
+            onItemClick={handleDropdownMenuClick}
             iconClassName='sm:hover:stroke-blue-200 cursor-pointer w-0 sm:w-auto'
           />
         </div>

--- a/components/goals/GoalTitleWithProgress.tsx
+++ b/components/goals/GoalTitleWithProgress.tsx
@@ -1,7 +1,7 @@
 'use client';
 import IconFlag from '@/public/icons/IconFlag';
-import DropdownMenu from './DropdownMenu';
-import ProgressBar from './ProgressBar';
+import DropdownMenu from '../common/DropdownMenu';
+import ProgressBar from '../common/ProgressBar';
 import useGoalQuery from '@/lib/hooks/useGoalQuery';
 import useTodoProgressQuery from '@/lib/hooks/useTodoProgressQuery';
 import { IconKebab } from '@/public/icons/IconKebab';
@@ -10,7 +10,7 @@ import { useDeleteGoalMutation } from '@/lib/hooks/useDeleteGoalMutation';
 import { useUpdateGoalMutation } from '@/lib/hooks/useUpdateGoalMutation';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import InputSlid from './InputSlid';
+import InputSlid from '../common/InputSlid';
 import { Goal } from '@/lib/types/todo';
 
 const GoalTitleWithProgress = ({ goalId, initialGoal }: { goalId: number; initialGoal: Goal }) => {
@@ -25,7 +25,7 @@ const GoalTitleWithProgress = ({ goalId, initialGoal }: { goalId: number; initia
 
   const router = useRouter();
 
-  const handleDropdaownMenuClick = (item: string) => {
+  const handleDropdownMenuClick = (item: string) => {
     if (item === '수정하기') {
       setIsEditClicked(true);
     } else if (item === '삭제하기') {
@@ -82,7 +82,7 @@ const GoalTitleWithProgress = ({ goalId, initialGoal }: { goalId: number; initia
             <DropdownMenu
               icon={IconKebab}
               dropdownList={['수정하기', '삭제하기']}
-              onItemClick={handleDropdaownMenuClick}
+              onItemClick={handleDropdownMenuClick}
             />
           </div>
         </div>

--- a/components/modal/ConfirmationModal.tsx
+++ b/components/modal/ConfirmationModal.tsx
@@ -7,6 +7,7 @@ interface ConfirmationModalProps {
   onChangeIsOpen: (value: boolean) => void;
   onConfirm: () => void;
   itemType: keyof typeof CONFIRMATION_ITEM_TEXTS;
+  itemTitle?: string;
   cancelText?: string;
   confirmText?: string;
   confirmButtonVariant?: 'filled' | 'outlined';
@@ -19,6 +20,7 @@ const ConfirmationModal = ({
   onChangeIsOpen,
   onConfirm,
   itemType,
+  itemTitle,
   cancelText = '취소',
   confirmText = '확인',
   confirmButtonVariant = 'filled',
@@ -31,7 +33,7 @@ const ConfirmationModal = ({
       <ModalContent closeOnClickOverlay={false} className='sm:w-[450px]'>
         <div className='flex flex-col items-center gap-4'>
           <h1 className='text-lg font-bold'>{title}</h1>
-          <p className='text-center whitespace-pre-line'>{message}</p>
+          <p className='text-center whitespace-pre-line'>{itemTitle ? `${itemTitle} ${message}` : message}</p>
           <div className='flex gap-4'>
             <Button className={cancelButtonClassName} variant='outlined' onClick={() => onChangeIsOpen(false)}>
               {cancelText}

--- a/components/nav/NavGoal.tsx
+++ b/components/nav/NavGoal.tsx
@@ -10,12 +10,24 @@ import InputSlid from '../common/InputSlid';
 import AddGoalButton from './AddGoalButton';
 import clsx from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import DropdownMenu from '../common/DropdownMenu';
+import { IconKebabWithCircle } from '@/public/icons/IconKebabWithCircle';
+import { useDeleteGoalMutation } from '@/lib/hooks/useDeleteGoalMutation';
+import { useUpdateGoalMutation } from '@/lib/hooks/useUpdateGoalMutation';
+import ConfirmationModal from '../modal/ConfirmationModal';
 
 const DEFAULT_INPUT_VALUE = '· ';
 const NavGoal = ({ className }: { className?: string }) => {
   const [isGoalInputVisible, setIsGoalInputVisible] = useState(false);
   const [goalInputValue, setGoalInputValue] = useState('');
   const [selectedGoalId, setSelectedGoalId] = useState<number | null>(null);
+  const [kebabClickedGoal, setKebabClickedGoal] = useState<Goal>();
+  const deleteGoal = useDeleteGoalMutation();
+  const updateGoal = useUpdateGoalMutation();
+
+  const [isEditFocused, setIsEditFocused] = useState(false);
+  const [editingGoalId, setEditingGoalId] = useState(-1);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const addGoal = useAddGoalMutation();
 
@@ -60,58 +72,140 @@ const NavGoal = ({ className }: { className?: string }) => {
     setGoalInputValue('· ');
   };
 
+  const handleDropdownMenuClick = (item: string) => {
+    if (item === '수정하기') {
+      setIsEditFocused(true);
+    } else if (item === '삭제하기') {
+      setIsDeleteModalOpen(true);
+    }
+  };
+
+  const handleNavGoalKebabClick = (goal: Goal) => {
+    setKebabClickedGoal(goal);
+    setEditingGoalId(goal.id);
+  };
+
+  const handleGoalInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setGoalInputValue(e.target.value);
+  };
+
+  // 수정
+  const handleGoalEditSubmit = (e?: React.FormEvent) => {
+    e?.preventDefault();
+    updateGoal.mutate(
+      { id: kebabClickedGoal?.id ?? -1, updates: { title: goalInputValue.trim() } },
+      {
+        onSuccess: (data) => {
+          setGoalInputValue(data.title);
+          setIsEditFocused(false);
+        },
+      }
+    );
+  };
+
+  // 삭제
+  const handleGoalDelete = () => {
+    deleteGoal.mutate({ goalId: kebabClickedGoal?.id ?? -1 });
+    setIsDeleteModalOpen(false);
+  };
+
   return (
-    <div className={twMerge(clsx('flex flex-wrap px-4 py-6 gap-4', className))}>
-      <div className='flex items-center gap-2 order-1 sm:order-1 lg:order-1'>
-        <div className='w-6 h-6 flex justify-center items-center'>
-          <IconFlagSmall />
-        </div>
-        <div className='text-lg font-medium text-slate-800'>목표</div>
-      </div>
-
-      {/* 새 목표 버튼 (모바일에서는 타이틀 옆, 태블릿과 데스크탑에서는 맨 아래로) */}
-      <AddGoalButton
-        className='order-2 sm:order-4 lg:order-4 ml-auto sm:mx-0 lg:mx-0 gap-[2px] rounded-xl text-sm px-3 py-2 sm:p-3 lg:p-3 sm:px-6 lg:px-6 mt-0 w-[84px] sm:w-full lg:w-full'
-        onClick={handleAddGoalButtonClick}
-      />
-
-      <div className='order-3 sm:order-2 lg:order-2 w-full max-h-72 overflow-y-auto h-auto'>
-        {data?.pages.map((page, idx) => (
-          <div key={page.nextCursor || idx} className='flex-col'>
-            {page.goals.map((goal: Goal) => (
-              <Link
-                href={`/goals/${goal.id}`}
-                key={goal.id}
-                className={clsx(
-                  'flex text-slate-700 text-sm font-medium rounded-lg p-2 hover:bg-slate-50',
-                  goal.id === selectedGoalId ? 'bg-slate-50' : 'bg-white'
-                )}
-                onClick={() => handleGoalClick(goal.id)}
-              >
-                {`${DEFAULT_INPUT_VALUE}${goal.title}`}
-              </Link>
-            ))}
+    <>
+      <div className={twMerge(clsx('flex flex-wrap px-4 py-6 gap-4', className))}>
+        <div className='flex items-center gap-2 order-1 sm:order-1 lg:order-1'>
+          <div className='w-6 h-6 flex justify-center items-center'>
+            <IconFlagSmall />
           </div>
-        ))}
-        <div ref={ref}></div>
-      </div>
-
-      {/* 새 목표 클릭시 생성되는 인풋 */}
-      {isGoalInputVisible && (
-        <div className='order-4 sm:order-3 lg:order-3 w-full flex items-center'>
-          <form onSubmit={handleGoalSubmit} className='w-full h-auto m-0'>
-            <InputSlid
-              type='text'
-              className='m-0'
-              inputClassName='flex-grow p-2 m-0 text-sm font-medium bg-white rounded-lg border-2 border-blue-200'
-              value={goalInputValue}
-              onChange={handleInputChange}
-              autoFocus
-            />
-          </form>
+          <div className='text-lg font-medium text-slate-800'>목표</div>
         </div>
-      )}
-    </div>
+
+        {/* 새 목표 버튼 (모바일에서는 타이틀 옆, 태블릿과 데스크탑에서는 맨 아래로) */}
+        <AddGoalButton
+          className='order-2 sm:order-4 lg:order-4 ml-auto sm:mx-0 lg:mx-0 gap-[2px] rounded-xl text-sm px-3 py-2 sm:p-3 lg:p-3 sm:px-6 lg:px-6 mt-0 w-[84px] sm:w-full lg:w-full'
+          onClick={handleAddGoalButtonClick}
+        />
+
+        <div className='order-3 sm:order-2 lg:order-2 w-full max-h-72 overflow-y-auto h-auto'>
+          {data?.pages.map((page, idx) => (
+            <div key={page.nextCursor || idx} className='flex-col'>
+              {page.goals.map((goal: Goal) => (
+                <div className='flex items-center group rounded-lg  hover:bg-slate-50 ' key={goal.id}>
+                  {/* kebab에서 수정하기를 클릭하면 Input, 그 외에는 일반 Link로 goal list */}
+                  {isEditFocused && editingGoalId === goal.id ? (
+                    <form onSubmit={handleGoalEditSubmit} className='w-full h-auto m-0'>
+                      <InputSlid
+                        type='text'
+                        placeholder={goal?.title}
+                        className='my-0 mx-2'
+                        inputClassName='flex-grow py-1 px-2 text-xs font-medium rounded-lg'
+                        value={goalInputValue}
+                        onChange={handleGoalInputChange}
+                        autoFocus
+                        onBlur={(e) => {
+                          if (!e.currentTarget.contains(e.relatedTarget)) {
+                            setIsEditFocused(false);
+                          }
+                        }}
+                      />
+                    </form>
+                  ) : (
+                    <>
+                      <Link
+                        href={`/goals/${goal.id}`}
+                        key={goal.id}
+                        className={clsx(
+                          'flex flex-grow text-slate-700 text-sm font-medium group-hover:bg-slate-50 p-2 hover-trigger',
+                          goal.id === selectedGoalId ? 'bg-slate-50' : 'bg-white'
+                        )}
+                        onClick={() => handleGoalClick(goal.id)}
+                      >
+                        {`${DEFAULT_INPUT_VALUE}${goal.title}`}
+                      </Link>
+                      <div
+                        className='items-center justify-center ml-auto hidden group-hover:flex'
+                        onClick={() => handleNavGoalKebabClick(goal)}
+                      >
+                        <DropdownMenu
+                          icon={IconKebabWithCircle}
+                          dropdownList={['수정하기', '삭제하기']}
+                          onItemClick={handleDropdownMenuClick}
+                          className='space-y-0'
+                          dropdownListClassName='text-sm'
+                        />
+                      </div>
+                    </>
+                  )}
+                </div>
+              ))}
+            </div>
+          ))}
+          <div ref={ref}></div>
+        </div>
+
+        {/* 새 목표 클릭시 생성되는 인풋 */}
+        {isGoalInputVisible && (
+          <div className='order-4 sm:order-3 lg:order-3 w-full flex items-center'>
+            <form onSubmit={handleGoalSubmit} className='w-full h-auto m-0'>
+              <InputSlid
+                type='text'
+                className='m-0'
+                inputClassName='flex-grow p-2 m-0 text-sm font-medium bg-white rounded-lg border-2 border-blue-200'
+                value={goalInputValue}
+                onChange={handleInputChange}
+                autoFocus
+              />
+            </form>
+          </div>
+        )}
+      </div>
+      <ConfirmationModal
+        isOpen={isDeleteModalOpen}
+        onChangeIsOpen={setIsDeleteModalOpen}
+        itemType='goal'
+        itemTitle={kebabClickedGoal?.title}
+        onConfirm={handleGoalDelete}
+      />
+    </>
   );
 };
 

--- a/components/nav/NavGoal.tsx
+++ b/components/nav/NavGoal.tsx
@@ -167,7 +167,7 @@ const NavGoal = ({ className }: { className?: string }) => {
                         {`${DEFAULT_INPUT_VALUE}${goal.title}`}
                       </Link>
                       <div
-                        className='items-center justify-center ml-auto hidden sm:flex lg:hidden group-hover:flex'
+                        className='items-center justify-center ml-auto flex lg:hidden group-hover:flex'
                         onClick={() => handleNavGoalKebabClick(goal)}
                       >
                         <DropdownMenu

--- a/components/nav/NavGoal.tsx
+++ b/components/nav/NavGoal.tsx
@@ -167,7 +167,7 @@ const NavGoal = ({ className }: { className?: string }) => {
                         {`${DEFAULT_INPUT_VALUE}${goal.title}`}
                       </Link>
                       <div
-                        className='items-center justify-center ml-auto hidden group-hover:flex'
+                        className='items-center justify-center ml-auto hidden sm:flex lg:hidden group-hover:flex'
                         onClick={() => handleNavGoalKebabClick(goal)}
                       >
                         <DropdownMenu

--- a/components/nav/NavGoal.tsx
+++ b/components/nav/NavGoal.tsx
@@ -97,10 +97,10 @@ const NavGoal = ({ className }: { className?: string }) => {
   const handleGoalEditSubmit = (e?: React.FormEvent) => {
     e?.preventDefault();
     updateGoal.mutate(
-      { id: kebabClickedGoal?.id ?? -1, updates: { title: newGoalInputValue.trim() } },
+      { id: kebabClickedGoal?.id ?? -1, updates: { title: existingGoalInputValue.trim() } },
       {
         onSuccess: (data) => {
-          setNewGoalInputValue(data.title);
+          setExistingGoalInputValue(data.title);
           setIsEditFocused(false);
         },
       }

--- a/components/notes/NoteDetail.tsx
+++ b/components/notes/NoteDetail.tsx
@@ -45,7 +45,7 @@ const NoteDetail = ({ id, goalTitle, todoTitle }: NoteDetailProps) => {
     );
   };
 
-  const handleDropdaownMenuClick = (item: string) => {
+  const handleDropdownMenuClick = (item: string) => {
     if (item === '수정하기') {
       // 수정하기페이지로 이동
       router.push(
@@ -143,7 +143,7 @@ const NoteDetail = ({ id, goalTitle, todoTitle }: NoteDetailProps) => {
             <DropdownMenu
               icon={IconKebabWithCircle}
               dropdownList={['수정하기', '삭제하기']}
-              onItemClick={handleDropdaownMenuClick}
+              onItemClick={handleDropdownMenuClick}
             />
           </div>
         </div>

--- a/components/notes/NoteItem.tsx
+++ b/components/notes/NoteItem.tsx
@@ -21,7 +21,7 @@ const NoteItem: React.FC<NoteItemProps> = ({ note }) => {
     deleteNote.mutate({ noteId: note.id });
   };
 
-  const handleDropdaownMenuClick = (item: string) => {
+  const handleDropdownMenuClick = (item: string) => {
     if (item === '수정하기') {
       // 수정하기페이지로 이동
       router.push(
@@ -52,7 +52,7 @@ const NoteItem: React.FC<NoteItemProps> = ({ note }) => {
             <DropdownMenu
               icon={IconKebabWithCircle}
               dropdownList={['수정하기', '삭제하기']}
-              onItemClick={handleDropdaownMenuClick}
+              onItemClick={handleDropdownMenuClick}
               className='hover:stroke-slate-100 hover:fill-slate-200 cursor-pointer transition-all duration-200 w-0 group-hover:w-auto group-focus-within:w-auto'
             />
           </div>


### PR DESCRIPTION
## ✅ 작업 내용

목표 여럿을 삭제하려면 매번 각각의 목표 상세 페이지에서 삭제하기 버튼을 눌러야하는 번거로움이 있어 nav에서 목표 hover시 더보기 버튼에서 수정/삭제 할 수 있도록 기능을 추가했습니다.
- 데스크탑: hover하면 케밥 아이콘이 보이게 되며 클릭시 목표 상세와 마찬가지로 수정하기/삭제하기 메뉴로 기능을 사용할 수 있습니다.
- 모바일/태블릿: hover하지 않아도 기본적으로 케밥 아이콘이 보이며 기능은 동일합니다.
  - 모바일의 경우 drawer를 사용하려 했으나 목표 클릭시 해당 목표 상세 페이지로 이동하는 기능이 우선이며 수정과 삭제는 페이지 내부에서 해결 할 수 있어 태블릿 데스크탑과 동일하게 케밥 아이콘을 그대로 사용했습니다.

nav에서 목표 삭제의 경우 기존 삭제 메세지 '목표를 삭제하시겠습니까' 의 경우 어떤 목표를 삭제하는지 헷갈릴 수 있어 ConfirmationModal.tsx에 itemTitle?:string 을 추가해 '{itemTitle} 목표를 삭제하시겠습니까?' 메세지로 변경했습니다. 

그 외
- DropdownMenu를 사용하는 TodoIcon, NoteDetail, NoteItem에 작성된 함수의 오타를 수정했습니다.
- DropdownMenu가 nav에서 사용 될 때 드롭다운 메뉴가 나타날 공간이 부족할 시 자동으로 스크롤하도록 변경했습니다.
- GoalTitleWithProgress.tsx 파일을 common 폴더에서 goals 폴더로 옮겼습니다.

## 📸 스크린샷 / GIF / Link

모바일

![image](https://github.com/user-attachments/assets/91292f72-9c3c-41e8-b182-96f92453ed76)


목표 수정

![Kapture 2024-11-13 at 11 31 50](https://github.com/user-attachments/assets/ebc921dd-7af3-4d87-9d21-bc5ab0b2188f)


목표 삭제

![Kapture 2024-11-13 at 11 20 02](https://github.com/user-attachments/assets/fd934887-4b74-4fe5-8029-4ff7a7760440)


close #275 