### PR TITLE
[ NAV ] 새 목표 input에 내용이 있을 경우 새 목표 버튼 색상 변경

### DIFF
--- a/components/nav/AddGoalButton.tsx
+++ b/components/nav/AddGoalButton.tsx
@@ -5,14 +5,15 @@ import clsx from 'clsx';
 
 interface addGoalButton {
   className: string;
+  currentInputValue: string;
   onClick?: () => void;
 }
 
-const AddGoalButton = ({ className, onClick }: addGoalButton) => {
+const AddGoalButton = ({ className, currentInputValue, onClick }: addGoalButton) => {
   const buttonClass = twMerge(clsx('text-nowrap', className));
   return (
-    <ButtonSlid className={buttonClass} variant='outlined' onClick={onClick}>
-      <IconPlusSmall stroke='#3B82F6' />
+    <ButtonSlid className={buttonClass} variant={currentInputValue === '' ? 'outlined' : 'filled'} onClick={onClick}>
+      <IconPlusSmall stroke={currentInputValue === '' ? '#3B82F6' : undefined} />
       <span>새 목표</span>
     </ButtonSlid>
   );

--- a/components/nav/NavGoal.tsx
+++ b/components/nav/NavGoal.tsx
@@ -126,6 +126,7 @@ const NavGoal = ({ className }: { className?: string }) => {
         {/* 새 목표 버튼 (모바일에서는 타이틀 옆, 태블릿과 데스크탑에서는 맨 아래로) */}
         <AddGoalButton
           className='order-2 sm:order-4 lg:order-4 ml-auto sm:mx-0 lg:mx-0 gap-[2px] rounded-xl text-sm px-3 py-2 sm:p-3 lg:p-3 sm:px-6 lg:px-6 mt-0 w-[84px] sm:w-full lg:w-full'
+          currentInputValue={newGoalInputValue.replace(DEFAULT_INPUT_VALUE, '').trim()}
           onClick={handleAddGoalButtonClick}
         />
 


### PR DESCRIPTION
## ✅ 작업 내용
MVP 피드백 중 새 목표를 입력 후 어떻게 제출해야 할지 헷갈린다는 의견이 있었습니다.
목표 추가 버튼이 input 생성 / input value 제출 역할을 모두 하지만 제출 역할을 유저가 알기 쉽지 않았던 것 같습니다.
input 내용이 채워지면 버튼의 스타일을 다르게 변경해 버튼 클릭으로 제출을 유도하도록 수정했습니다.

## 📸 스크린샷 / GIF / Link
![Kapture 2024-11-14 at 15 30 11](https://github.com/user-attachments/assets/e12d41b9-336d-4cee-a3d5-f22991b4c9d2)

close #304 
