### PR TITLE
[ 할 일 수정 ] 파일이 삭제 수정이 안되는 문제 

### DIFF
--- a/lib/utils/cleanedFormData.ts
+++ b/lib/utils/cleanedFormData.ts
@@ -3,6 +3,8 @@ interface FormData {
 }
 
 const cleanedFormData = (data: FormData) =>
-  Object.fromEntries(Object.entries(data).filter(([, value]) => Boolean(value) || value === 'done'));
+  Object.fromEntries(
+    Object.entries(data).map(([key, value]) => [key, Boolean(value) || value === 'done' ? value : null])
+  );
 
 export default cleanedFormData;


### PR DESCRIPTION
close #323

## ✅ 작업 내용
수정시 빈 값이면 기존에는 [cleanedFormData.ts](https://github.com/FESI-4-4/slid-todo/compare/feature/323?expand=1#diff-88b7dab8986924932b4e7566a4d373941f78b723d93bbaeb423b25c708e6a20a)에서 키 자체를 지웠었습니다.
수정 후 빈 값이면 null을 줍니다(PATCH는 수정될 키의 값이 필요).

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항

## ✍ 궁금한 것
