### PR TITLE
[ 모든 할 일 ] 초기값 SSR

### DIFF
--- a/app/(nav)/todos/page.tsx
+++ b/app/(nav)/todos/page.tsx
@@ -2,13 +2,21 @@ import TodosContent from '@/components/allTodos/TodosContent';
 import { TodosProvider } from '@/components/allTodos/TodosContext';
 import TodosHeader from '@/components/allTodos/TodosHeader';
 import PageContainer from '@/components/common/pageLayout/PageContainer';
+import baseFetch from '@/lib/api/baseFetch';
+import { GetTodosResponse } from '@/lib/types/todo';
+import { cookies } from 'next/headers';
 
 export default async function Alltodos() {
+  const accessToken = cookies().get('accessToken');
+  const TodosInitialData: GetTodosResponse = await baseFetch(`${process.env.NEXT_PUBLIC_BASE_URL}/todos`, {
+    headers: { Authorization: `Bearer ${accessToken?.value}` },
+    cache: 'no-store',
+  });
   return (
     <PageContainer>
       <TodosProvider>
         <TodosHeader />
-        <TodosContent />
+        <TodosContent TodosInitialData={TodosInitialData} />
       </TodosProvider>
     </PageContainer>
   );

--- a/components/allTodos/AllTodoList.tsx
+++ b/components/allTodos/AllTodoList.tsx
@@ -7,19 +7,32 @@ import { useIntersectionObserver } from '@/lib/hooks/useIntersectionObserver';
 import { useEffect } from 'react';
 import { useTodosInfiniteQuery } from '@/lib/hooks/useTodosInfiniteQuery';
 import Loading from '@/app/loading';
+import { GetTodosResponse } from '@/lib/types/todo';
 
-const AllTodoList: React.FC = () => {
+interface AllTodoListProps {
+  TodosInitialData: GetTodosResponse;
+}
+
+const AllTodoList: React.FC<AllTodoListProps> = ({ TodosInitialData }) => {
   const { setTotalCount } = useTodoContext();
   const params = useSearchParams();
   const status = params.get('status');
-  const { data, fetchNextPage, hasNextPage, isFetching } = useTodosInfiniteQuery({
-    size: 40,
-    done: status === 'completed' ? true : status === 'in-progress' ? false : undefined,
-  });
+  const { data, fetchNextPage, hasNextPage, isFetching } = useTodosInfiniteQuery(
+    {
+      size: 20,
+      done: status === 'completed' ? true : status === 'in-progress' ? false : undefined,
+    },
+    {
+      initialData: {
+        pages: [TodosInitialData],
+        pageParams: [null],
+      },
+    }
+  );
   const loadMoreRef = useIntersectionObserver({
     onIntersect: fetchNextPage,
     enabled: !!hasNextPage && !isFetching,
-    threshold: 0.5,
+    threshold: 0.1,
     rootMargin: '100px',
   });
   const todos = data?.pages.flatMap((page) => page.todos) ?? [];
@@ -30,7 +43,9 @@ const AllTodoList: React.FC = () => {
   }, [data?.pages, setTotalCount]);
 
   if (!todos.length && !isFetching) {
-    return <div className='flex justify-center items-center text-sm text-slate-500'>등록한 일이 없어요</div>;
+    return (
+      <div className='flex justify-center items-center text-sm text-slate-500 min-h-[50px]'>등록한 일이 없어요</div>
+    );
   }
 
   return (

--- a/components/allTodos/TodosContent.tsx
+++ b/components/allTodos/TodosContent.tsx
@@ -1,12 +1,17 @@
 import Filters from './Filters';
 import AllTodoList from './AllTodoList';
+import { GetTodosResponse } from '@/lib/types/todo';
 
-const TodosContent = () => {
+interface TodosContentProps {
+  TodosInitialData: GetTodosResponse;
+}
+
+const TodosContent: React.FC<TodosContentProps> = ({ TodosInitialData }) => {
   return (
     <>
       <section className='sm:p-6 p-4 bg-white rounded-xl flex flex-col gap-4'>
         <Filters />
-        <AllTodoList />
+        <AllTodoList TodosInitialData={TodosInitialData} />
       </section>
     </>
   );

--- a/components/common/todoItem/TodoImage.tsx
+++ b/components/common/todoItem/TodoImage.tsx
@@ -8,17 +8,14 @@ interface TodoImageProps {
 
 const TodoImage = ({ imageUrl, className }: TodoImageProps) => {
   return (
-    console.log('imageUrl', imageUrl),
-    (
-      <Image
-        src={imageUrl}
-        alt='todo-image'
-        width={400}
-        height={400}
-        className={twMerge('w-full h-auto rounded-lg object-cover', className)}
-        priority={true}
-      />
-    )
+    <Image
+      src={imageUrl}
+      alt='todo-image'
+      width={400}
+      height={400}
+      className={twMerge('w-full h-auto rounded-lg object-cover', className)}
+      priority={true}
+    />
   );
 };
 

--- a/components/common/todoItem/index.tsx
+++ b/components/common/todoItem/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useEffect, useState } from 'react';
+import { memo } from 'react';
 import { Todo } from '@/lib/types/todo';
 import CheckIcon from './CheckIcon';
 import TodoIcon from './TodoIcon';
@@ -32,16 +32,6 @@ const areEqual = (prevProps: TodoItemProps, nextProps: TodoItemProps) => {
 };
 
 const TodoItem: React.FC<TodoItemProps> = memo(({ data, viewGoal, variant = 'default' }) => {
-  const [imageUrl, setImageUrl] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (variant === 'detailed' && isValidImageUrl(data.fileUrl)) {
-      setImageUrl(data.fileUrl);
-    } else {
-      setImageUrl(null);
-    }
-  }, [data.fileUrl, variant]);
-
   const layoutClasses = {
     article: twMerge(
       'text-sm grid gap-x-2 items-center',
@@ -70,9 +60,9 @@ const TodoItem: React.FC<TodoItemProps> = memo(({ data, viewGoal, variant = 'def
       <div className={layoutClasses.todoIcon}>
         <TodoIcon data={data} />
       </div>
-      {imageUrl && variant === 'detailed' && (
+      {isValidImageUrl(data.fileUrl) && variant === 'detailed' && (
         <div className={layoutClasses.image}>
-          <TodoImage imageUrl={imageUrl} />
+          <TodoImage imageUrl={data.fileUrl!} />
         </div>
       )}
     </article>

--- a/lib/hooks/useNotesInfiniteQuery.ts
+++ b/lib/hooks/useNotesInfiniteQuery.ts
@@ -13,7 +13,7 @@ export const useNotesInfiniteQuery = (searchParams: NotesSearchParams = {}, opti
     queryFn: ({ pageParam }) => {
       const stringifiedParams: Record<string, string> = {
         size: String(searchParams.size),
-        cursor: String(pageParam),
+        ...(pageParam !== null && { cursor: String(pageParam) }),
         ...(searchParams.goalId !== undefined && { goalId: String(searchParams.goalId) }),
       };
 

--- a/lib/hooks/useTodosInfiniteQuery.ts
+++ b/lib/hooks/useTodosInfiniteQuery.ts
@@ -8,25 +8,22 @@ interface TodosSearchParams {
   size?: number;
 }
 
-export const useTodosInfiniteQuery = (searchParams: TodosSearchParams = {}) => {
+export const useTodosInfiniteQuery = (searchParams: TodosSearchParams = {}, options = {}) => {
   return useInfiniteQuery<GetTodosResponse>({
     queryKey: ['todos', searchParams],
     queryFn: ({ pageParam }) => {
       // 기본 파라미터 설정
       const stringifiedParams: Record<string, string> = {
         size: String(searchParams.size || 20),
+        ...(pageParam !== null && { cursor: String(pageParam) }),
         ...(searchParams.goalId !== undefined && { goalId: String(searchParams.goalId) }),
         ...(searchParams.done !== undefined && { done: String(searchParams.done) }),
       };
-      // pageParam이 초기값(1)이 아닐 때만 cursor 추가
-      if (pageParam !== 1) {
-        stringifiedParams.cursor = String(pageParam);
-      }
 
       const params = new URLSearchParams(stringifiedParams);
       return baseFetch(`/4-4-dev/todos?${params.toString()}`);
     },
-    initialPageParam: 1,
+    initialPageParam: null,
     getNextPageParam: (lastPage) => {
       if (lastPage.nextCursor) {
         return lastPage.nextCursor;
@@ -34,5 +31,6 @@ export const useTodosInfiniteQuery = (searchParams: TodosSearchParams = {}) => {
       return undefined;
     },
     staleTime: Infinity,
+    ...options,
   });
 };


### PR DESCRIPTION
close #338 

## ✅ 작업 내용
- 모든 할일 페이지 초기값 서버에서 패칭
- 이미지 컴포넌트 랜더링 판단을 서버에서 가능하게 바꾸어 이미지 컴포넌트도 SSR가능하게 바꿨습니다.
- 결과: 20~40을 오가던 lightHouse 점수 무려 88 상승! (주요 문제 레이아웃 쉬프트)
- 낮았던 이유
  1. 초기값을 프론트에서 랜더링 하다보니 레이아웃 변화가 생김(다른 페이지 보다 글씨, 이미지, ui 크기가 상당히 큼 -> 영향력^) -> 초기값 SSR로 해결
  2. 이미지 컴포넌트를 나타낼지를 프론트에서 판단하다보니 레이아웃 변화가 생김 -> 서버에서 판단 > 해결

- 효과: 모든 할 일 페이지 처음 접속시 레이아웃 변화 없이 빠른 속도로 사용자가 내용을 볼 수 있음
## 📸 스크린샷 / GIF / Link
![image](https://github.com/user-attachments/assets/2083ca75-1d6a-4735-a35c-cfff87d094be)


## 📌 이슈 사항

## ✍ 궁금한 것
