### PR TITLE
[ 전체 레이아웃 ] CSS 구조변경

### DIFF
--- a/app/(nav)/dashboard/page.tsx
+++ b/app/(nav)/dashboard/page.tsx
@@ -10,7 +10,7 @@ export default function DashboardPage() {
       <div className='hidden sm:block lg:block'>
         <PageHeader title='대시보드' />
       </div>
-      <div className='w-full flex flex-col sm:flex-row lg:flex-row gap-2 sm:gap-6'>
+      <div className='w-full flex flex-col sm:flex-row sm:flex-wrap gap-2 sm:gap-6'>
         <RecentTodo />
         <Progress />
       </div>

--- a/app/(nav)/layout.tsx
+++ b/app/(nav)/layout.tsx
@@ -8,7 +8,7 @@ export default function NavLayout({
   return (
     <div className='flex flex-col min-h-screen sm:flex-row lg:flex-row'>
       <Nav />
-      <div className='flex-1 min-h-screen'>{children}</div>
+      <div className='flex-1'>{children}</div>
     </div>
   );
 }

--- a/app/(nav)/layout.tsx
+++ b/app/(nav)/layout.tsx
@@ -6,9 +6,9 @@ export default function NavLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className='flex flex-col h-screen sm:flex-row lg:flex-row'>
+    <div className='flex flex-col min-h-screen sm:flex-row lg:flex-row'>
       <Nav />
-      <div className='flex-1'>{children}</div>
+      <div className='flex-1 min-h-screen'>{children}</div>
     </div>
   );
 }

--- a/app/(nav)/todos/[todoId]/create/page.tsx
+++ b/app/(nav)/todos/[todoId]/create/page.tsx
@@ -2,7 +2,7 @@ import NoteFormSections from '../_view/NoteFormSections';
 
 export default function Page() {
   return (
-    <main className='lg:flex h-screen overflow-auto'>
+    <main className='lg:flex h-[calc(100vh-3.5rem)] sm:h-screen overflow-auto'>
       <NoteFormSections />
     </main>
   );

--- a/app/(nav)/todos/[todoId]/note/[noteId]/page.tsx
+++ b/app/(nav)/todos/[todoId]/note/[noteId]/page.tsx
@@ -19,7 +19,7 @@ export default async function Page({ params }: { params: { noteId: string } }) {
 
   const { title, content, linkUrl } = response;
   return (
-    <main className='lg:flex h-screen overflow-auto'>
+    <main className='lg:flex h-[calc(100vh-3.5rem)] sm:h-screen overflow-auto'>
       <NoteFormSections title={title} content={content} linkUrl={linkUrl ?? ''} method='PATCH' noteId={noteId} />
     </main>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -19,4 +19,48 @@ body {
   .scrollbar-width-none {
     scrollbar-width: none;
   }
+  .scroll-container {
+    scrollbar-width: thin; /* Firefox */
+    scrollbar-color: transparent transparent;
+  }
+
+  .scroll-container:hover {
+    scrollbar-color: rgba(136, 136, 136, 0.8) transparent; /* Firefox */
+  }
+
+  .scroll-container::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+    background-color: transparent;
+  }
+
+  .scroll-container:hover::-webkit-scrollbar-thumb {
+    background-color: rgba(136, 136, 136, 0.8); /* 스크롤바 색상 */
+    border-radius: 4px;
+  }
+
+  .scroll-container:hover::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(85, 85, 85, 0.8); /* hover 색상 */
+  }
+  ::-webkit-scrollbar {
+    width: 8px; /* 세로 스크롤 바 너비 */
+    height: 8px; /* 가로 스크롤 바 높이 */
+  }
+
+  /* 스크롤 바의 트랙(배경) */
+  ::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 10px;
+  }
+
+  /* 스크롤 바의 핸들(이동할 때 잡는 부분) */
+  ::-webkit-scrollbar-thumb {
+    background: #888;
+    border-radius: 10px;
+  }
+
+  /* 스크롤 바의 핸들에 마우스를 올렸을 때 */
+  ::-webkit-scrollbar-thumb:hover {
+    background: #555;
+  }
 }

--- a/components/common/Modal.tsx
+++ b/components/common/Modal.tsx
@@ -111,7 +111,7 @@ const ModalContent = ({
           <div
             role='dialog'
             aria-modal='true'
-            className={twMerge('fixed inset-0 flex justify-center items-center', overlayClassName)}
+            className={twMerge('fixed inset-0 flex justify-center items-center z-20', overlayClassName)}
             onClick={(e) => e.stopPropagation()}
           >
             <div className='absolute inset-0 bg-black opacity-50' onClick={handleClickOverlay}></div>

--- a/components/common/Sheet.tsx
+++ b/components/common/Sheet.tsx
@@ -87,12 +87,14 @@ SheetTrigger.displayName = 'SheetTrigger';
 const SheetContent = ({
   position,
   className,
+  dialogClassName,
   closeOnClickOverlay = true,
   children,
   ...props
 }: ComponentPropsWithoutRef<'div'> & {
   position: 'top' | 'bottom' | 'right' | 'left';
   closeOnClickOverlay?: boolean;
+  dialogClassName?: string;
 }) => {
   const { isOpen, handleClose, willBeClosed } = useSheetContext();
 
@@ -159,7 +161,12 @@ const SheetContent = ({
     <>
       {isOpen &&
         createPortal(
-          <div role='dialog' aria-modal='true' className='fixed inset-0' onClick={(e) => e.stopPropagation()}>
+          <div
+            role='dialog'
+            aria-modal='true'
+            className={twMerge('fixed inset-0 z-20', dialogClassName)}
+            onClick={(e) => e.stopPropagation()}
+          >
             <div
               className='absolute inset-0 bg-black opacity-0 transition-opacity duration-300'
               onClick={handleClickOverlay}
@@ -167,7 +174,7 @@ const SheetContent = ({
             ></div>
             <div
               className={twMerge(
-                'absolute p-6 bg-white z-10 transition-transform duration-150',
+                'absolute p-6 bg-white z-20 transition-transform duration-150',
                 variants[position],
                 className
               )}

--- a/components/common/pageLayout/PageContainer.tsx
+++ b/components/common/pageLayout/PageContainer.tsx
@@ -10,7 +10,9 @@ interface PageContainerProps {
 
 const PageContainer = ({ children, className = '', containerClassName = '' }: PageContainerProps) => {
   return (
-    <main className={twMerge(clsx('bg-slate-100 w-full min-h-screen', containerClassName))}>
+    <main
+      className={twMerge(clsx('bg-slate-100 w-full min-h-[calc(100vh-3.5rem)] sm:min-h-screen', containerClassName))}
+    >
       <section className={twMerge(clsx('lg:px-20 sm:px-6 px-4 py-6 max-w-[792px] h-full', className))}>
         {children}
       </section>

--- a/components/common/pageLayout/PageContainer.tsx
+++ b/components/common/pageLayout/PageContainer.tsx
@@ -10,7 +10,7 @@ interface PageContainerProps {
 
 const PageContainer = ({ children, className = '', containerClassName = '' }: PageContainerProps) => {
   return (
-    <main className={twMerge(clsx('bg-slate-100 w-full h-screen overflow-auto', containerClassName))}>
+    <main className={twMerge(clsx('bg-slate-100 w-full min-h-screen', containerClassName))}>
       <section className={twMerge(clsx('lg:px-20 sm:px-6 px-4 py-6 max-w-[792px] h-full', className))}>
         {children}
       </section>

--- a/components/common/todoItem/index.tsx
+++ b/components/common/todoItem/index.tsx
@@ -34,14 +34,13 @@ const areEqual = (prevProps: TodoItemProps, nextProps: TodoItemProps) => {
 const TodoItem: React.FC<TodoItemProps> = memo(({ data, viewGoal, variant = 'default' }) => {
   const layoutClasses = {
     article: twMerge(
-      'text-sm grid gap-x-2 items-start', // items-center를 items-start로 변경
+      'text-sm grid gap-x-2 items-start',
       variant === 'default' ? 'grid-cols-[auto_minmax(0,1fr)_auto]' : 'grid-cols-[auto_minmax(0,1fr)_auto_auto]'
-      // minmax(0,1fr)을 사용하여 자식 요소가 부모 컨테이너를 넘어가지 않도록 함
     ),
-    content: 'min-w-0 flex flex-col gap-1', // 내용을 감싸는 컨테이너 추가
+    content: 'min-w-0 flex flex-col',
     checkIcon: 'row-start-1 col-start-1 h-6',
-    title: 'min-w-0 line-clamp-1', // min-w-0 추가
-    goal: 'min-w-0', // min-w-0 추가
+    title: 'min-w-0 line-clamp-1',
+    goal: 'min-w-0',
     todoIcon: twMerge('row-start-1 col-start-3', variant === 'detailed' && 'col-start-4'),
     image: 'row-start-3 col-span-full w-full mt-2',
   };

--- a/components/dashboard/Progress.tsx
+++ b/components/dashboard/Progress.tsx
@@ -9,7 +9,7 @@ import useTodoProgressQuery from '@/lib/hooks/useTodoProgressQuery';
 const Progress = () => {
   const { data } = useTodoProgressQuery();
   return (
-    <section className='relative flex flex-1 min-w-80 min-h-[250px] bg-blue-500 rounded-xl'>
+    <section className='relative flex flex-1 min-w-72 min-h-[250px] bg-blue-500 rounded-xl'>
       <div className='flex-col pl-6 pt-4'>
         <div className='w-10 h-10 bg-slate-900 rounded-[15px] grid place-content-center' aria-hidden='true'>
           <IconProgress />

--- a/components/dashboard/Progress.tsx
+++ b/components/dashboard/Progress.tsx
@@ -9,7 +9,7 @@ import useTodoProgressQuery from '@/lib/hooks/useTodoProgressQuery';
 const Progress = () => {
   const { data } = useTodoProgressQuery();
   return (
-    <section className='relative flex flex-1 min-w-0 min-h-[250px] bg-blue-500 rounded-xl'>
+    <section className='relative flex flex-1 min-w-80 min-h-[250px] bg-blue-500 rounded-xl'>
       <div className='flex-col pl-6 pt-4'>
         <div className='w-10 h-10 bg-slate-900 rounded-[15px] grid place-content-center' aria-hidden='true'>
           <IconProgress />

--- a/components/dashboard/RecentTodo.tsx
+++ b/components/dashboard/RecentTodo.tsx
@@ -11,7 +11,7 @@ const RecentTodo = () => {
   const recentTodos = data?.pages[0];
   return (
     <section
-      className='flex flex-1 flex-col min-w-80 min-h-[250px] bg-white rounded-xl border border-slate-100 gap-4
+      className='flex flex-1 flex-col min-w-72 min-h-[250px] bg-white rounded-xl border border-slate-100 gap-4
       px-4 pb-6 pt-4 sm:px-6 sm:pb-6 sm:pt-4
     '
     >

--- a/components/dashboard/RecentTodo.tsx
+++ b/components/dashboard/RecentTodo.tsx
@@ -11,7 +11,7 @@ const RecentTodo = () => {
   const recentTodos = data?.pages[0];
   return (
     <section
-      className='flex flex-1 flex-col min-w-0 min-h-[250px] bg-white rounded-xl border border-slate-100 gap-4
+      className='flex flex-1 flex-col min-w-80 min-h-[250px] bg-white rounded-xl border border-slate-100 gap-4
       px-4 pb-6 pt-4 sm:px-6 sm:pb-6 sm:pt-4
     '
     >

--- a/components/nav/Nav.tsx
+++ b/components/nav/Nav.tsx
@@ -1,48 +1,56 @@
 'use client';
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
-import { motion } from 'framer-motion';
+import { motion, AnimatePresence } from 'framer-motion';
 import { twMerge } from 'tailwind-merge';
 import { usePathname } from 'next/navigation';
 import TodoAddModal from '../modal/todoModal/TodoAddModal';
 import NavHeader from './NavHeader';
 import NavContent from './NavContent';
 import NavMobileHeader from './NavMobileHeader';
+import { useWindowResize } from '@/lib/hooks/useWindowResize';
+import { navContentVariants, navVariants } from '@/lib/animations/variants';
 
 const Nav = () => {
-  const [isLeftNavOpen, setIsLeftNavOpen] = useState(true); // 왼쪽 nav 열림 여부
-  const [isTodoModalOpen, setIsTodoModalOpen] = useState(false); // 할 일 모달 열림 여부
+  const [isLeftNavOpen, setIsLeftNavOpen] = useState(true);
+  const [isTodoModalOpen, setIsTodoModalOpen] = useState(false);
   const [currentPageLabel, setCurrentPageLabel] = useState('대시보드');
   const pathname = usePathname();
+  useWindowResize({ setIsLeftNavOpen });
 
   const handleTodoModalOpen = () => {
     setIsTodoModalOpen(true);
   };
 
-  // 페이지 이동 시
   useEffect(() => {
     setCurrentPageLabel(document.title.split('|')[0].trim());
   }, [pathname]);
 
   return (
     <nav aria-label='사이드바 네비게이션 메뉴'>
-      {/* 데스크탑 */}
+      {/* 왼쪽 네브 (데스크탑, 테블릿) */}
       <motion.section
-        initial={{ width: '280px' }}
-        animate={{ width: isLeftNavOpen ? '280px' : '64px' }}
-        transition={{ duration: 0.1 }}
+        initial='open'
+        animate={isLeftNavOpen ? 'open' : 'closed'}
+        variants={navVariants}
         className={twMerge(
           clsx(
-            'hidden sm:flex sm:sticky sm:top-0 sm:left-0 flex-col border-r-[1px] min-h-screen flex-shrink-0 divide-slate-200'
+            'hidden sm:flex sm:sticky sm:top-0 sm:left-0 flex-col border-r-[1px] min-h-screen flex-shrink-0 divide-slate-200 overflow-hidden'
           )
         )}
       >
-        {/* 윗부분: 로고 및 열기/닫기 버튼 */}
         <NavHeader isLeftNavOpen={isLeftNavOpen} handleNavToggleButtonClick={() => setIsLeftNavOpen(!isLeftNavOpen)} />
-        {isLeftNavOpen && <NavContent handleTodoModalOpen={handleTodoModalOpen} />}
+        <AnimatePresence mode='wait'>
+          {isLeftNavOpen && (
+            <motion.div key='nav-content' variants={navContentVariants} initial='closed' animate='open' exit='closed'>
+              <NavContent handleTodoModalOpen={handleTodoModalOpen} />
+            </motion.div>
+          )}
+        </AnimatePresence>
       </motion.section>
-      {/* 모바일 헤더 */}
+      {/* 위쪽네브 (모바일) */}
       <NavMobileHeader currentPageLabel={currentPageLabel} handleTodoModalOpen={handleTodoModalOpen} />
+      {/* 할일 추가 모달 */}
       <TodoAddModal isOpen={isTodoModalOpen} onChangeIsOpen={setIsTodoModalOpen} />
     </nav>
   );

--- a/components/nav/Nav.tsx
+++ b/components/nav/Nav.tsx
@@ -27,32 +27,37 @@ const Nav = () => {
   }, [pathname]);
 
   return (
-    <nav aria-label='사이드바 네비게이션 메뉴' className='sticky top-0 z-10'>
-      {/* 왼쪽 네브 (데스크탑, 테블릿) */}
-      <motion.section
-        initial='open'
-        animate={isLeftNavOpen ? 'open' : 'closed'}
-        variants={navVariants}
-        className={twMerge(
-          clsx(
-            'hidden sm:flex sm:sticky sm:top-0 sm:left-0 flex-col border-r-[1px] min-h-screen flex-shrink-0 divide-slate-200 overflow-hidden'
-          )
-        )}
-      >
-        <NavHeader isLeftNavOpen={isLeftNavOpen} handleNavToggleButtonClick={() => setIsLeftNavOpen(!isLeftNavOpen)} />
-        <AnimatePresence mode='wait'>
-          {isLeftNavOpen && (
-            <motion.div key='nav-content' variants={navContentVariants} initial='closed' animate='open' exit='closed'>
-              <NavContent handleTodoModalOpen={handleTodoModalOpen} />
-            </motion.div>
+    <>
+      <nav aria-label='사이드바 네비게이션 메뉴'>
+        {/* 왼쪽 네브 (데스크탑, 테블릿) */}
+        <motion.section
+          initial='open'
+          animate={isLeftNavOpen ? 'open' : 'closed'}
+          variants={navVariants}
+          className={twMerge(
+            clsx(
+              'hidden sm:flex sticky top-0 left-0 flex-col border-r-[1px] min-h-screen flex-shrink-0 divide-slate-200 overflow-hidden'
+            )
           )}
-        </AnimatePresence>
-      </motion.section>
+        >
+          <NavHeader
+            isLeftNavOpen={isLeftNavOpen}
+            handleNavToggleButtonClick={() => setIsLeftNavOpen(!isLeftNavOpen)}
+          />
+          <AnimatePresence mode='wait'>
+            {isLeftNavOpen && (
+              <motion.div key='nav-content' variants={navContentVariants} initial='closed' animate='open' exit='closed'>
+                <NavContent handleTodoModalOpen={handleTodoModalOpen} />
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </motion.section>
+      </nav>
       {/* 위쪽네브 (모바일) */}
       <NavMobileHeader currentPageLabel={currentPageLabel} handleTodoModalOpen={handleTodoModalOpen} />
       {/* 할일 추가 모달 */}
       <TodoAddModal isOpen={isTodoModalOpen} onChangeIsOpen={setIsTodoModalOpen} />
-    </nav>
+    </>
   );
 };
 

--- a/components/nav/Nav.tsx
+++ b/components/nav/Nav.tsx
@@ -27,7 +27,7 @@ const Nav = () => {
   }, [pathname]);
 
   return (
-    <nav aria-label='사이드바 네비게이션 메뉴' className='sticky top-0'>
+    <nav aria-label='사이드바 네비게이션 메뉴' className='sticky top-0 z-30'>
       {/* 왼쪽 네브 (데스크탑, 테블릿) */}
       <motion.section
         initial='open'

--- a/components/nav/Nav.tsx
+++ b/components/nav/Nav.tsx
@@ -27,7 +27,7 @@ const Nav = () => {
   }, [pathname]);
 
   return (
-    <nav aria-label='사이드바 네비게이션 메뉴'>
+    <nav aria-label='사이드바 네비게이션 메뉴' className='sticky top-0'>
       {/* 왼쪽 네브 (데스크탑, 테블릿) */}
       <motion.section
         initial='open'

--- a/components/nav/Nav.tsx
+++ b/components/nav/Nav.tsx
@@ -1,114 +1,48 @@
 'use client';
 import clsx from 'clsx';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { twMerge } from 'tailwind-merge';
 import { usePathname } from 'next/navigation';
-import { SheetClose, SheetContent, SheetProvider, SheetTrigger } from '../common/Sheet';
 import TodoAddModal from '../modal/todoModal/TodoAddModal';
 import NavHeader from './NavHeader';
 import NavContent from './NavContent';
-
-type widthType = 'mobile' | 'tablet' | 'desktop';
+import NavMobileHeader from './NavMobileHeader';
 
 const Nav = () => {
-  const [isDesktopNavOpen, setIsDesktopNavOpen] = useState(true); // 데스크탑용 nav 열림 여부
-  const [isSheetOpen, setIsSheetOpen] = useState(false); // 모바일, 태블릿용 sheet nav 열림 여부
-  const [isFullyOpen, setIsFullyOpen] = useState(true); // 데스브탑에서 nav가 충분히 열린 후에 컨텐츠 보이게 하기 위한 변수
+  const [isLeftNavOpen, setIsLeftNavOpen] = useState(true); // 왼쪽 nav 열림 여부
   const [isTodoModalOpen, setIsTodoModalOpen] = useState(false); // 할 일 모달 열림 여부
   const [currentPageLabel, setCurrentPageLabel] = useState('대시보드');
   const pathname = usePathname();
-  const hasMounted = useRef(false);
 
   const handleTodoModalOpen = () => {
     setIsTodoModalOpen(true);
   };
 
-  const handleNavToggleButtonClick = (widthType?: widthType) => {
-    if (widthType === 'desktop') {
-      setIsDesktopNavOpen(!isDesktopNavOpen);
-    } else {
-      setIsSheetOpen(!isSheetOpen);
-    }
-  };
-
   // 페이지 이동 시
   useEffect(() => {
-    // 첫 마운트 이후에만(페이지 이동시에만)실행
-    if (hasMounted.current) {
-      setIsSheetOpen(false); // 모바일/데스크탑일 경우 페이지 이동시 nav 접기
-      setCurrentPageLabel(document.title.split('|')[0].trim());
-    } else {
-      hasMounted.current = true;
-    }
+    setCurrentPageLabel(document.title.split('|')[0].trim());
   }, [pathname]);
 
   return (
     <nav aria-label='사이드바 네비게이션 메뉴'>
-      {/* 모바일/태블릿용 sheet nav */}
-      <section
-        className={clsx(
-          'flex sm:flex lg:hidden flex-col h-auto sm:h-screen border-r-[1px] flex-shrink-0 divide-slate-200'
-        )}
-      >
-        <SheetProvider isOpen={isSheetOpen} onChangeIsOpen={setIsSheetOpen}>
-          <SheetTrigger>
-            <NavHeader
-              isDesktopNavOpen={isDesktopNavOpen}
-              isSheetOpen={false}
-              handleNavToggleButtonClick={handleNavToggleButtonClick}
-              currentPageLabel={currentPageLabel}
-            />
-          </SheetTrigger>
-
-          {/* 태블릿 */}
-          <SheetContent position={'left'} className={'sm:w-[280px] p-0'}>
-            <NavHeader
-              isDesktopNavOpen={isDesktopNavOpen}
-              isSheetOpen={isSheetOpen}
-              handleNavToggleButtonClick={handleNavToggleButtonClick}
-              currentPageLabel={currentPageLabel}
-            >
-              <SheetClose />
-            </NavHeader>
-            <NavContent handleTodoModalOpen={handleTodoModalOpen} />
-          </SheetContent>
-        </SheetProvider>
-      </section>
-
       {/* 데스크탑 */}
       <motion.section
         initial={{ width: '280px' }}
-        animate={{ width: isDesktopNavOpen ? '280px' : '64px' }}
+        animate={{ width: isLeftNavOpen ? '280px' : '64px' }}
         transition={{ duration: 0.1 }}
         className={twMerge(
-          clsx('hidden sm:hidden lg:flex flex-col border-r-[1px] h-screen flex-shrink-0 divide-slate-200')
+          clsx(
+            'hidden sm:flex sm:sticky sm:top-0 sm:left-0 flex-col border-r-[1px] min-h-screen flex-shrink-0 divide-slate-200'
+          )
         )}
-        onAnimationComplete={() => {
-          if (isDesktopNavOpen) {
-            setIsFullyOpen(true); // 애니메이션 완료 후 모두 다 펼쳐진 후에 하단 콘텐츠 보이기
-          }
-        }}
       >
         {/* 윗부분: 로고 및 열기/닫기 버튼 */}
-        <NavHeader
-          isDesktopNavOpen={isDesktopNavOpen}
-          isSheetOpen={isSheetOpen}
-          handleNavToggleButtonClick={handleNavToggleButtonClick}
-        />
-
-        {/* 아래부분: NavContent (사이드바가 모두 열렸을 때만 보임) */}
-        {isDesktopNavOpen && isFullyOpen && (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.1 }}
-            className='w-full flex flex-col items-start'
-          >
-            <NavContent handleTodoModalOpen={handleTodoModalOpen} />
-          </motion.div>
-        )}
+        <NavHeader isLeftNavOpen={isLeftNavOpen} handleNavToggleButtonClick={() => setIsLeftNavOpen(!isLeftNavOpen)} />
+        {isLeftNavOpen && <NavContent handleTodoModalOpen={handleTodoModalOpen} />}
       </motion.section>
+      {/* 모바일 헤더 */}
+      <NavMobileHeader currentPageLabel={currentPageLabel} handleTodoModalOpen={handleTodoModalOpen} />
       <TodoAddModal isOpen={isTodoModalOpen} onChangeIsOpen={setIsTodoModalOpen} />
     </nav>
   );

--- a/components/nav/Nav.tsx
+++ b/components/nav/Nav.tsx
@@ -28,17 +28,16 @@ const Nav = () => {
 
   return (
     <>
-      <nav aria-label='사이드바 네비게이션 메뉴'>
+      <nav
+        aria-label='사이드바 네비게이션 메뉴'
+        className='hidden sm:block h-screen sticky top-0 left-0 overflow-hidden'
+      >
         {/* 왼쪽 네브 (데스크탑, 테블릿) */}
         <motion.section
           initial='open'
           animate={isLeftNavOpen ? 'open' : 'closed'}
           variants={navVariants}
-          className={twMerge(
-            clsx(
-              'hidden sm:flex sticky top-0 left-0 flex-col border-r-[1px] min-h-screen flex-shrink-0 divide-slate-200 overflow-hidden'
-            )
-          )}
+          className={twMerge(clsx('hidden h-full sm:flex flex-col flex-shrink-0 divide-slate-200'))}
         >
           <NavHeader
             isLeftNavOpen={isLeftNavOpen}
@@ -46,7 +45,14 @@ const Nav = () => {
           />
           <AnimatePresence mode='wait'>
             {isLeftNavOpen && (
-              <motion.div key='nav-content' variants={navContentVariants} initial='closed' animate='open' exit='closed'>
+              <motion.div
+                key='nav-content'
+                variants={navContentVariants}
+                initial='closed'
+                animate='open'
+                exit='closed'
+                className='h-full overflow-auto scroll-container'
+              >
                 <NavContent handleTodoModalOpen={handleTodoModalOpen} />
               </motion.div>
             )}

--- a/components/nav/Nav.tsx
+++ b/components/nav/Nav.tsx
@@ -27,7 +27,7 @@ const Nav = () => {
   }, [pathname]);
 
   return (
-    <nav aria-label='사이드바 네비게이션 메뉴' className='sticky top-0 z-30'>
+    <nav aria-label='사이드바 네비게이션 메뉴' className='sticky top-0 z-10'>
       {/* 왼쪽 네브 (데스크탑, 테블릿) */}
       <motion.section
         initial='open'

--- a/components/nav/NavGoal.tsx
+++ b/components/nav/NavGoal.tsx
@@ -139,7 +139,7 @@ const NavGoal = ({ className }: { className?: string }) => {
           <span className='text-lg font-medium text-slate-800'>목표</span>
         </div>
 
-        <div className='order-3 sm:order-2 lg:order-2 w-full max-h-72 overflow-y-auto h-auto'>
+        <div className='order-3 sm:order-2 lg:order-2 w-full max-h-72 overflow-auto scroll-container h-auto'>
           {data?.pages.map((page, idx) => (
             <ul key={page.nextCursor || idx} className='flex flex-col gap-1 p-1'>
               {page.goals.map((goal: Goal) => (

--- a/components/nav/NavHeader.tsx
+++ b/components/nav/NavHeader.tsx
@@ -1,17 +1,14 @@
 import { IconFold } from '@/public/icons/IconFold';
-import { IconHamburger } from '@/public/icons/IconHamburger';
 import { ImageLogo } from '@/public/images/ImageLogo';
 import { ImageLogoWithText } from '@/public/images/ImageLogoWithText';
 import { twMerge } from 'tailwind-merge';
 import clsx from 'clsx';
 import Link from 'next/link';
 
-type widthType = 'mobile' | 'tablet' | 'desktop';
-
 type NavHeaderProps = {
-  isDesktopNavOpen: boolean;
-  isSheetOpen: boolean;
-  handleNavToggleButtonClick: (widthType?: widthType) => void;
+  isLeftNavOpen?: boolean;
+  isSheetOpen?: boolean;
+  handleNavToggleButtonClick?: () => void;
   currentPageLabel?: string;
   children?: React.ReactNode;
 };
@@ -35,7 +32,7 @@ const NavButton = ({ onClick, icon, className }: NavButtonProps) => (
     tabIndex={0}
     className={twMerge(
       clsx(
-        'grid place-content-center hover:cursor-pointer w-6 h-6 p-1 bg-white hover:bg-slate-100 active:bg-slate-300 rounded-lg border-[1.5px] border-slate-400',
+        'sm:grid place-content-center hover:cursor-pointer w-6 h-6 p-1 bg-white hover:bg-slate-100 active:bg-slate-300 rounded-lg border-[1.5px] border-slate-400',
         className
       )
     )}
@@ -49,65 +46,16 @@ const NavSection = ({ children, className }: NavSectionProps) => (
   <div className={twMerge('w-full justify-center items-center gap-4', className)}>{children}</div>
 );
 
-const NavHeader = ({
-  isDesktopNavOpen,
-  isSheetOpen,
-  handleNavToggleButtonClick,
-  currentPageLabel,
-  children,
-}: NavHeaderProps) => {
+const NavHeader = ({ isLeftNavOpen, handleNavToggleButtonClick }: NavHeaderProps) => {
   return (
-    <>
-      {/* 데스크탑 */}
-      <NavSection
-        className={clsx(
-          'hidden sm:hidden lg:flex',
-          isDesktopNavOpen ? 'flex-row justify-between p-4' : 'sm:flex-col lg:flex-col p-4'
-        )}
-      >
-        <Link href='/dashboard'>{isDesktopNavOpen ? <ImageLogoWithText /> : <ImageLogo />}</Link>
-        <NavButton
-          onClick={() => handleNavToggleButtonClick('desktop')}
-          icon={<IconFold isFold={!isDesktopNavOpen} />}
-        />
-      </NavSection>
-
-      {/* 태블릿 */}
-      <NavSection className={clsx('hidden sm:flex lg:hidden p-4', isSheetOpen ? 'flex-row justify-start' : 'flex-col')}>
-        {isSheetOpen ? (
-          <Link href='/dashboard'>
-            <ImageLogoWithText />
-          </Link>
-        ) : (
-          <>
-            <Link href='/dashboard'>
-              <ImageLogo />
-            </Link>
-            <NavButton onClick={() => handleNavToggleButtonClick('tablet')} icon={<IconFold isFold={!isSheetOpen} />} />
-          </>
-        )}
-      </NavSection>
-
-      {/* 모바일 */}
-      <NavSection className='flex sm:hidden lg:hidden flex-row px-[14px] py-4 justify-normal'>
-        {isSheetOpen ? (
-          <>
-            <IconHamburger aria-hidden='true' />
-            <h1 className='text-base font-semibold text-slate-900'>{currentPageLabel}</h1>
-            <div className='ml-auto flex justify-center items-center'>{children}</div>
-          </>
-        ) : (
-          <>
-            <IconHamburger
-              onClick={() => handleNavToggleButtonClick('mobile')}
-              className='hover:cursor-pointer'
-              aria-label='모바일 메뉴 열기'
-            />
-            <h1 className='text-base font-semibold text-slate-900'>{currentPageLabel}</h1>
-          </>
-        )}
-      </NavSection>
-    </>
+    <NavSection
+      className={clsx('flex', isLeftNavOpen ? 'flex-row justify-between p-4' : 'sm:flex-col lg:flex-col p-4')}
+    >
+      <Link href='/dashboard'>{isLeftNavOpen ? <ImageLogoWithText /> : <ImageLogo />}</Link>
+      {handleNavToggleButtonClick && (
+        <NavButton onClick={handleNavToggleButtonClick} icon={<IconFold isFold={!isLeftNavOpen} />} />
+      )}
+    </NavSection>
   );
 };
 

--- a/components/nav/NavHeader.tsx
+++ b/components/nav/NavHeader.tsx
@@ -4,6 +4,7 @@ import { ImageLogoWithText } from '@/public/images/ImageLogoWithText';
 import { twMerge } from 'tailwind-merge';
 import clsx from 'clsx';
 import Link from 'next/link';
+import NavSection from './NavSection';
 
 type NavHeaderProps = {
   isLeftNavOpen?: boolean;
@@ -11,11 +12,6 @@ type NavHeaderProps = {
   handleNavToggleButtonClick?: () => void;
   currentPageLabel?: string;
   children?: React.ReactNode;
-};
-
-type NavSectionProps = {
-  children: React.ReactNode;
-  className?: string;
 };
 
 type NavButtonProps = {
@@ -40,10 +36,6 @@ const NavButton = ({ onClick, icon, className }: NavButtonProps) => (
   >
     {icon}
   </div>
-);
-
-const NavSection = ({ children, className }: NavSectionProps) => (
-  <div className={twMerge('w-full justify-center items-center gap-4', className)}>{children}</div>
 );
 
 const NavHeader = ({ isLeftNavOpen, handleNavToggleButtonClick }: NavHeaderProps) => {

--- a/components/nav/NavMobileHeader.tsx
+++ b/components/nav/NavMobileHeader.tsx
@@ -17,14 +17,16 @@ const NavMobileHeader: React.FC<NavMobileHeader> = ({ currentPageLabel, handleTo
   }, [pathname]);
   return (
     <>
-      <NavSection className='flex sm:hidden flex-row px-[14px] py-4 justify-normal backdrop-saturate-180 backdrop-blur-sm'>
-        <IconHamburger
-          onClick={() => setIsSheetOpen(true)}
-          className='hover:cursor-pointer'
-          aria-label='모바일 메뉴 열기'
-        />
-        <h1 className='text-base font-semibold text-slate-900'>{currentPageLabel}</h1>
-      </NavSection>
+      <nav aria-label='모바일 헤더' className='fixed top-0 left-0 right-0 z-10'>
+        <NavSection className='flex sm:hidden flex-row px-[14px] py-4 justify-normal backdrop-saturate-180 backdrop-blur-sm'>
+          <IconHamburger
+            onClick={() => setIsSheetOpen(true)}
+            className='hover:cursor-pointer'
+            aria-label='모바일 메뉴 열기'
+          />
+          <h1 className='text-base font-semibold text-slate-900'>{currentPageLabel}</h1>
+        </NavSection>
+      </nav>
       <NavMobileSheet
         isSheetOpen={isSheetOpen}
         setIsSheetOpen={setIsSheetOpen}

--- a/components/nav/NavMobileHeader.tsx
+++ b/components/nav/NavMobileHeader.tsx
@@ -1,22 +1,13 @@
 import { IconHamburger } from '@/public/icons/IconHamburger';
 import { useEffect, useState } from 'react';
-import { twMerge } from 'tailwind-merge';
 import NavMobileSheet from './NavMobileSheet';
 import { usePathname } from 'next/navigation';
-
-type NavSectionProps = {
-  children: React.ReactNode;
-  className?: string;
-};
+import NavSection from './NavSection';
 
 type NavMobileHeader = {
   currentPageLabel?: string;
   handleTodoModalOpen: () => void;
 };
-
-const NavSection = ({ children, className }: NavSectionProps) => (
-  <div className={twMerge('w-full justify-center items-center gap-4', className)}>{children}</div>
-);
 
 const NavMobileHeader: React.FC<NavMobileHeader> = ({ currentPageLabel, handleTodoModalOpen }) => {
   const pathname = usePathname();
@@ -26,7 +17,7 @@ const NavMobileHeader: React.FC<NavMobileHeader> = ({ currentPageLabel, handleTo
   }, [pathname]);
   return (
     <>
-      <NavSection className='flex sm:hidden lg:hidden flex-row px-[14px] py-4 justify-normal'>
+      <NavSection className='flex sm:hidden flex-row px-[14px] py-4 justify-normal backdrop-saturate-180 backdrop-blur-sm'>
         <IconHamburger
           onClick={() => setIsSheetOpen(true)}
           className='hover:cursor-pointer'

--- a/components/nav/NavMobileHeader.tsx
+++ b/components/nav/NavMobileHeader.tsx
@@ -1,0 +1,46 @@
+import { IconHamburger } from '@/public/icons/IconHamburger';
+import { useEffect, useState } from 'react';
+import { twMerge } from 'tailwind-merge';
+import NavMobileSheet from './NavMobileSheet';
+import { usePathname } from 'next/navigation';
+
+type NavSectionProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+type NavMobileHeader = {
+  currentPageLabel?: string;
+  handleTodoModalOpen: () => void;
+};
+
+const NavSection = ({ children, className }: NavSectionProps) => (
+  <div className={twMerge('w-full justify-center items-center gap-4', className)}>{children}</div>
+);
+
+const NavMobileHeader: React.FC<NavMobileHeader> = ({ currentPageLabel, handleTodoModalOpen }) => {
+  const pathname = usePathname();
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  useEffect(() => {
+    setIsSheetOpen(false);
+  }, [pathname]);
+  return (
+    <>
+      <NavSection className='flex sm:hidden lg:hidden flex-row px-[14px] py-4 justify-normal'>
+        <IconHamburger
+          onClick={() => setIsSheetOpen(true)}
+          className='hover:cursor-pointer'
+          aria-label='모바일 메뉴 열기'
+        />
+        <h1 className='text-base font-semibold text-slate-900'>{currentPageLabel}</h1>
+      </NavSection>
+      <NavMobileSheet
+        isSheetOpen={isSheetOpen}
+        setIsSheetOpen={setIsSheetOpen}
+        handleTodoModalOpen={handleTodoModalOpen}
+      />
+    </>
+  );
+};
+
+export default NavMobileHeader;

--- a/components/nav/NavMobileHeader.tsx
+++ b/components/nav/NavMobileHeader.tsx
@@ -17,7 +17,7 @@ const NavMobileHeader: React.FC<NavMobileHeader> = ({ currentPageLabel, handleTo
   }, [pathname]);
   return (
     <>
-      <nav aria-label='모바일 헤더' className='fixed top-0 left-0 right-0 z-10'>
+      <nav aria-label='모바일 헤더' className=' sticky top-0 left-0 right-0 z-10'>
         <NavSection className='flex sm:hidden flex-row px-[14px] py-4 justify-normal backdrop-saturate-180 backdrop-blur-sm'>
           <IconHamburger
             onClick={() => setIsSheetOpen(true)}

--- a/components/nav/NavMobileSheet.tsx
+++ b/components/nav/NavMobileSheet.tsx
@@ -11,7 +11,7 @@ interface NavMobileSheetProps {
 const NavMobileSheet: React.FC<NavMobileSheetProps> = ({ isSheetOpen, setIsSheetOpen, handleTodoModalOpen }) => {
   return (
     <SheetProvider isOpen={isSheetOpen} onChangeIsOpen={setIsSheetOpen}>
-      <SheetContent position={'top'} dialogClassName={'sm:hidden'}>
+      <SheetContent position={'top'} dialogClassName={'sm:hidden'} className='p-0'>
         <div className='flex items-center justify-between pt-3 px-4 pb-4'>
           <ImageLogoWithText />
           <SheetClose />

--- a/components/nav/NavMobileSheet.tsx
+++ b/components/nav/NavMobileSheet.tsx
@@ -1,0 +1,25 @@
+import { SheetClose, SheetContent, SheetProvider } from '../common/Sheet';
+import NavContent from './NavContent';
+import { ImageLogoWithText } from '@/public/images/ImageLogoWithText';
+
+interface NavMobileSheetProps {
+  isSheetOpen: boolean;
+  setIsSheetOpen: (isOpen: boolean) => void;
+  handleTodoModalOpen: () => void;
+}
+
+const NavMobileSheet: React.FC<NavMobileSheetProps> = ({ isSheetOpen, setIsSheetOpen, handleTodoModalOpen }) => {
+  return (
+    <SheetProvider isOpen={isSheetOpen} onChangeIsOpen={setIsSheetOpen}>
+      <SheetContent position={'top'} className={'sm:w-[280px] p-0'}>
+        <div className='flex items-center justify-between pt-3 px-4 pb-4'>
+          <ImageLogoWithText />
+          <SheetClose />
+        </div>
+        <NavContent handleTodoModalOpen={handleTodoModalOpen} />
+      </SheetContent>
+    </SheetProvider>
+  );
+};
+
+export default NavMobileSheet;

--- a/components/nav/NavMobileSheet.tsx
+++ b/components/nav/NavMobileSheet.tsx
@@ -11,7 +11,7 @@ interface NavMobileSheetProps {
 const NavMobileSheet: React.FC<NavMobileSheetProps> = ({ isSheetOpen, setIsSheetOpen, handleTodoModalOpen }) => {
   return (
     <SheetProvider isOpen={isSheetOpen} onChangeIsOpen={setIsSheetOpen}>
-      <SheetContent position={'top'} className={'sm:w-[280px] p-0'}>
+      <SheetContent position={'top'} dialogClassName={'sm:hidden'}>
         <div className='flex items-center justify-between pt-3 px-4 pb-4'>
           <ImageLogoWithText />
           <SheetClose />

--- a/components/nav/NavSection.tsx
+++ b/components/nav/NavSection.tsx
@@ -1,0 +1,12 @@
+import { twMerge } from 'tailwind-merge';
+
+type NavSectionProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+const NavSection = ({ children, className }: NavSectionProps) => (
+  <div className={twMerge('w-full justify-center items-center gap-4', className)}>{children}</div>
+);
+
+export default NavSection;

--- a/lib/animations/variants.ts
+++ b/lib/animations/variants.ts
@@ -35,3 +35,46 @@ export const staggerChildren = {
     },
   },
 };
+
+export const navVariants = {
+  open: {
+    width: '280px',
+    transition: {
+      type: 'spring',
+      stiffness: 400,
+      damping: 30,
+      mass: 1.2,
+    },
+  },
+  closed: {
+    width: '64px',
+    transition: {
+      type: 'spring',
+      stiffness: 400,
+      damping: 30,
+      mass: 1.2,
+    },
+  },
+};
+
+export const navContentVariants = {
+  open: {
+    opacity: 1,
+    x: 0,
+    transition: {
+      type: 'spring',
+      stiffness: 300,
+      damping: 24,
+      delay: 0.1,
+    },
+  },
+  closed: {
+    opacity: 0,
+    x: -20,
+    transition: {
+      type: 'spring',
+      stiffness: 300,
+      damping: 24,
+    },
+  },
+};

--- a/lib/hooks/useWindowResize.ts
+++ b/lib/hooks/useWindowResize.ts
@@ -1,0 +1,38 @@
+'use client';
+import { useEffect, useCallback, useRef } from 'react';
+import debounce from '../utils/debounce';
+import { TABLET_BREAKPOINT } from '@/constants';
+
+interface UseWindowResizeProps {
+  setIsLeftNavOpen: (isOpen: boolean) => void;
+}
+
+export const useWindowResize = ({ setIsLeftNavOpen }: UseWindowResizeProps) => {
+  const wasOverThreshold = useRef<boolean | null>(null);
+
+  const handleResize = useCallback(() => {
+    const width = window.innerWidth;
+    const isOverThreshold = width >= TABLET_BREAKPOINT;
+
+    // 이전 상태와 현재 상태가 다를 때만 실행
+    if (wasOverThreshold.current !== null && isOverThreshold !== wasOverThreshold.current) {
+      setIsLeftNavOpen(isOverThreshold);
+    }
+
+    wasOverThreshold.current = isOverThreshold;
+  }, [setIsLeftNavOpen]);
+
+  useEffect(() => {
+    // 초기 상태 설정
+    const width = window.innerWidth;
+    wasOverThreshold.current = width >= TABLET_BREAKPOINT;
+    setIsLeftNavOpen(wasOverThreshold.current);
+
+    const debouncedHandleResize = debounce(handleResize, 200);
+    window.addEventListener('resize', debouncedHandleResize);
+
+    return () => {
+      window.removeEventListener('resize', debouncedHandleResize);
+    };
+  }, [handleResize, setIsLeftNavOpen]);
+};

--- a/lib/utils/debounce.ts
+++ b/lib/utils/debounce.ts
@@ -1,0 +1,12 @@
+const debounce = <T extends (...args: unknown[]) => void>(
+  func: T,
+  wait: number
+): ((...args: Parameters<T>) => void) => {
+  let timeout: NodeJS.Timeout | undefined;
+  return (...args: Parameters<T>) => {
+    if (timeout) clearTimeout(timeout);
+    timeout = setTimeout(() => func(...args), wait);
+  };
+};
+
+export default debounce;


### PR DESCRIPTION
close #344 

## ✅ 작업 내용
1. 네브 작동 상태관리 및 컴포넌트 정리
- 상태관리 축소
- 컴포넌트를 왼쪽네브, 모바일용헤더, 모바일용시트로 나눔
- 에니메이션 정리

- 네브가 자동으로 펴지거나 접혀질 때 애니메이션 작동합니다.(debounce로 0.2초 동안 화면 크기 변화가 없고 1024px 분기점을 지나야 작동)

https://github.com/user-attachments/assets/0b1f7992-bd92-4a6c-8462-bc7bf3091dad

- 테블릿 사이즈에서도 네브가 시트로 안나오고 폈을 때 원래 네브가 나오게했습니다.

https://github.com/user-attachments/assets/15c9f76f-2809-46fe-9496-813d67e568e8



기존 모바일 사이즈에서 모바일 헤더만큼의 높이가 추가되는 것을 조정했습니다.
적용 페이지(노트생성, 수정, 목표상세, 대시보드, 모든 할 일)
- before
![스크린샷 2024-11-18 092225](https://github.com/user-attachments/assets/a7fe32a3-001e-4cea-a5a3-ebe10d11b28a)

- after
![스크린샷 2024-11-18 092250](https://github.com/user-attachments/assets/cd2520c0-40aa-4ca0-a999-a48661c639f2)

2. 네브 리팩토링에 따라 모달과 sheet에 z-index를 추가했습니다.

3. 루트레이아웃의 높이를 수정하였습니다
- HTML의 스크롤 상속
- history.scrollRestoration를 자동 적용 받음(뒤로가기 앞으로가기 시 스크롤 위치 자동으로 복구)

- before

https://github.com/user-attachments/assets/01bd3f9f-61c3-4ceb-b486-886e248b15b8

- after

https://github.com/user-attachments/assets/ce5390c3-8b80-4182-83a0-bd9a4cd78ed6

4. 대시보드 페이지 레이아웃 조정했습니다.

https://github.com/user-attachments/assets/fa63e159-5593-4d67-9650-93a9483ff1e3




## 📌 이슈 사항

