### PR TITLE
[ 공통컴포넌트 ] 드롭다운 외부 클릭으로 닫히도록 수정

### DIFF
--- a/components/common/DropdownMenu.tsx
+++ b/components/common/DropdownMenu.tsx
@@ -128,7 +128,7 @@ const DropdownMenu = ({
         closeDropdown();
       }
     };
-    document.removeEventListener('mousedown', handleClickOutside);
+    document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [isDropdownOpen]);
 


### PR DESCRIPTION
## ✅ 작업 내용
드롭다운이 열린 상태에서 외부를 클릭해도 닫히지 않던 오류를 수정했습니다.

이전에 드롭다운 코드를 수정하면서 (https://github.com/FESI-4-4/slid-todo/commit/8425fa8380a6befcc091b24ef64e338f35ab2e60) 코드 구조를 단순화 하는 과정에서 삭제한 코드에 addEventListner가 빠져있었습니다. 

close #352