### PR TITLE
[ 대시보드 ] nav에서 목표 수정시 최근 할 일에서 수정되지 않던 오류 수정

### DIFF
--- a/lib/hooks/useUpdateGoalMutation.ts
+++ b/lib/hooks/useUpdateGoalMutation.ts
@@ -25,6 +25,7 @@ export const useUpdateGoalMutation = () => {
       });
       queryClient.invalidateQueries({ queryKey: ['goals'], refetchType: 'all' });
       queryClient.invalidateQueries({ queryKey: ['goal'] });
+      queryClient.invalidateQueries({ queryKey: ['todos'] });
     },
     onError: (error) => {
       toast.toast({


### PR DESCRIPTION
## ✅ 작업 내용
nav에서 목표 수정시 최근 할 일의 할 일 중 해당 목표가 있다면 함께 수정되어야하는데, 그러지 않았습니다.
목표 업데이트시 todo 쿼리도 함께 무효화하도록 변경해 함께 수정되도록 했습니다.

## 📸 스크린샷 / GIF / Link
![Kapture 2024-11-21 at 17 39 28](https://github.com/user-attachments/assets/2ed6dd52-1f19-4491-bd8c-4893ddbd2ddf)

close #359
