### PR TITLE
[ 전체 ] 긴 문자열 단어 단위 줄바꿈 추가 및 Nav, Goal 오류 수정

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -26,7 +26,10 @@ export default function Error() {
         <h1 id='error-heading' className='text-2xl font-semibold text-gray-800 mb-4'>
           오류가 발생했어요!
         </h1>
-        <p className='text-gray-600 mb-8'>예기치 않은 문제가 발생했어요. 홈으로 돌아가거나 다시 시도해 주세요.</p>
+        <p className='text-gray-600 mb-8 break-keep'>
+          예기치 않은 문제가 발생했어요. <br />
+          홈으로 돌아가거나 다시 시도해 주세요.
+        </p>
         <div className='flex flex-col sm:flex-row justify-center gap-4'>
           <Button onClick={handleGoBack} className='flex items-center justify-center'>
             다시 시도

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -21,17 +21,10 @@ export default function NotFound() {
     >
       <MainLogo className={`mb-[60px]`} aria-hidden='true' />
       <div className='bg-white rounded-lg shadow-xl p-8 max-w-md w-full text-center'>
-        {/* <Image
-          src='/'
-          alt=' 404 이미지'
-          className='mx-auto mb-6 rounded-full'
-          width={200}
-          height={200}
-        /> */}
         <h1 id='not-found-heading' className='text-2xl font-semibold text-gray-800 mb-4'>
           앗! 페이지를 찾을 수 없어요
         </h1>
-        <p className='text-gray-600 mb-8'>찾으시는 페이지가 사라졌거나 잘못된 주소를 입력하셨어요.</p>
+        <p className='text-gray-600 mb-8 break-keep'>찾으시는 페이지가 사라졌거나 잘못된 주소를 입력하셨어요.</p>
         <div className='flex flex-col sm:flex-row justify-center gap-4'>
           <Button onClick={handleGoBack} className='flex items-center justify-center'>
             뒤로 가기

--- a/components/dashboard/GoalTodo.tsx
+++ b/components/dashboard/GoalTodo.tsx
@@ -17,7 +17,7 @@ const GoalTodo = () => {
   }, [inView, fetchNextPage]);
 
   return (
-    <section className='flex mt-6 w-full pb-16 flex-grow' aria-labelledby='goal-todo-heading' role='region'>
+    <section className='flex mt-6 w-full pb-16 flex-grow' aria-labelledby='goal-todo-heading'>
       <div className='flex-col px-6 py-4 w-full h-auto bg-white rounded-xl border border-slate-100 relative'>
         <div className='flex items-center gap-2'>
           <div
@@ -26,7 +26,9 @@ const GoalTodo = () => {
           >
             <IconDashboardFlag />
           </div>
-          <h2 className='text-slate-800 text-lg font-semibold'>목표 별 할 일</h2>
+          <h2 id='goal-todo-heading' className='text-slate-800 text-lg font-semibold'>
+            목표 별 할 일
+          </h2>
         </div>
         {data?.pages[0].totalCount === 0 && (
           <span

--- a/components/dashboard/GoalTodoCard.tsx
+++ b/components/dashboard/GoalTodoCard.tsx
@@ -26,7 +26,7 @@ const GoalTodoCard = ({ goal }: { goal: Goal }) => {
               className='flex items-center text-lg font-bold rounded-lg group'
               href={`/goals/${goal.id.toString()}`}
             >
-              <h3>{goal.title || '목표이름'}</h3>
+              <h3 className='break-keep'>{goal.title || '목표이름'}</h3>
               <div className='group-hover:translate-x-1 transition-all' aria-hidden='true'>
                 <IconArrowRight />
               </div>

--- a/components/landingPage/FirstSection.tsx
+++ b/components/landingPage/FirstSection.tsx
@@ -21,7 +21,7 @@ const FirstSection = ({ isVisible }: SectionProps) => {
         <motion.h2 variants={fadeInUp} className='lg:text-4xl text-2xl font-bold mb-10'>
           효율적인 목표 관리와 체계적인 할 일 관리
         </motion.h2>
-        <motion.p variants={fadeInUp} className='lg:text-2xl mb-10'>
+        <motion.p variants={fadeInUp} className='lg:text-2xl mb-10 break-keep'>
           SlidToDo는 목표 설정과 할 일 관리에 필요한 모든 기능을 제공합니다. 목표부터 세부적인 할 일과 노트까지
           체계적으로 관리하여 효율적인 작업 흐름을 만들어 보세요.
         </motion.p>

--- a/components/landingPage/FourthSection.tsx
+++ b/components/landingPage/FourthSection.tsx
@@ -32,7 +32,7 @@ const FourthSection = ({ isVisible }: SectionProps) => {
         <motion.h2 variants={fadeInUp} className='text-4xl font-bold'>
           노트 작성과 임베드 기능
         </motion.h2>
-        <motion.p variants={fadeInUp} className='mt-4 lg:text-xl'>
+        <motion.p variants={fadeInUp} className='mt-4 lg:text-xl break-keep'>
           할 일마다 1:1로 연결된 노트에 더 자세한 내용을 기록할 수 있습니다. 유연한 임베드 기능으로 참고할 외부 자료나
           링크를 편하게 참조해 작업 효율성을 높여보세요.
         </motion.p>

--- a/components/landingPage/SecondSection.tsx
+++ b/components/landingPage/SecondSection.tsx
@@ -19,7 +19,7 @@ const SecondSection = ({ isVisible }: SectionProps) => {
         <motion.h2 variants={fadeInUp} className='text-4xl font-bold'>
           할 일 기능
         </motion.h2>
-        <motion.p variants={fadeInUp} className='mt-4 lg:text-xl'>
+        <motion.p variants={fadeInUp} className='mt-4 lg:text-xl break-keep'>
           각 할 일에는 관련 링크와 파일을 저장할 수 있으며, 필요한 노트를 추가해 더 자세한 내용을 기록할 수 있습니다.
           업무에 필요한 모든 자료를 한 곳에 정리해보세요.
         </motion.p>

--- a/components/landingPage/ThirdSection.tsx
+++ b/components/landingPage/ThirdSection.tsx
@@ -16,7 +16,7 @@ const ThirdSection = ({ isVisible }: SectionProps) => {
         <motion.h2 variants={fadeInUp} className='text-4xl font-bold'>
           목표 달성 현황
         </motion.h2>
-        <motion.p variants={fadeInUp} className='mt-4 lg:text-xl'>
+        <motion.p variants={fadeInUp} className='mt-4 lg:text-xl break-keep'>
           설정한 목표의 달성률을 직관적으로 확인할 수 있습니다. 할 일이 완료될 때마다 목표의 이미지로 달성률이
           시각화됩니다.
         </motion.p>

--- a/components/nav/NavGoal.tsx
+++ b/components/nav/NavGoal.tsx
@@ -157,7 +157,7 @@ const NavGoal = ({ className }: { className?: string }) => {
           {data?.pages.map((page, idx) => (
             <ul key={page.nextCursor || idx} className='flex flex-col gap-1 p-1' aria-label='목표 전체 리스트'>
               {page.goals.map((goal: Goal) => (
-                <li className='flex items-center group rounded-lg  hover:bg-slate-50 ' key={goal.id}>
+                <li className='flex items-center group rounded-lg hover:bg-slate-50 break-keep' key={goal.id}>
                   {/* kebab에서 수정하기를 클릭하면 Input, 그 외에는 일반 Link로 goal list */}
                   {isEditFocused && editingGoalId === goal.id ? (
                     <form

--- a/components/nav/NavMobileHeader.tsx
+++ b/components/nav/NavMobileHeader.tsx
@@ -20,6 +20,7 @@ const NavMobileHeader: React.FC<NavMobileHeader> = ({ currentPageLabel, handleTo
       <nav aria-label='모바일 헤더' className=' sticky top-0 left-0 right-0 z-10'>
         <NavSection className='flex sm:hidden flex-row px-[14px] py-4 justify-normal backdrop-saturate-180 backdrop-blur-sm'>
           <div
+            role='button'
             onClick={() => setIsSheetOpen(true)}
             className='hover:cursor-pointer'
             aria-label='모바일 네비게이션 열기/닫기'

--- a/components/nav/NavProfile.tsx
+++ b/components/nav/NavProfile.tsx
@@ -38,10 +38,10 @@ const Profile = ({ className }: { className?: string }) => {
       </div>
       <div className=' w-full flex sm:flex-col lg:flex-col justify-between gap-2'>
         <div className='flex-grow flex-col '>
-          <div className='text-xs sm:text-sm lg:text-sm font-semibold text-slate-800'>
+          <div className='text-xs sm:text-sm lg:text-sm font-semibold text-slate-800 break-all overflow-wrap break-word whitespace-normal'>
             {user?.name ?? '불러오는 중...'}
           </div>
-          <div className='text-xs sm:text-sm lg:text-sm font-medium text-slate-600'>
+          <div className='text-xs sm:text-sm lg:text-sm font-medium text-slate-600 break-all overflow-wrap break-word whitespace-normal'>
             {user?.email ?? '불러오는 중...'}
           </div>
         </div>

--- a/middleware.ts
+++ b/middleware.ts
@@ -28,8 +28,8 @@ export async function middleware(request: NextRequest) {
     }
   }
 
-  // /todos 하위 경로 접근 시 액세스토큰이 만료되었을 때
-  if (pathname.startsWith('/todos') && !accessToken && refreshToken) {
+  // /todos 나 /goals 하위 경로 접근 시 액세스토큰이 만료되었을 때
+  if ((pathname.startsWith('/todos') || pathname.startsWith('/goals')) && !accessToken && refreshToken) {
     const data = await fetchNewAccessToken(refreshToken, API_BASE_URL!);
 
     const response = setAuthCookies(new NextResponse(), data.accessToken, data.refreshToken);


### PR DESCRIPTION
## ✅ 작업 내용
- 긴 문장들에 break-keep(keep-all) 속성을 추가해 단어 단위로 줄바꿈 되도록 수정했습니다.(랜딩페이지, 대시보드 목표 카드 제목, not-found, error)
- Nav 유저 이름과 이메일이 긴 경우 화면 밖으로 벗어나던 오류를 자동 줄바꿈하도록 수정했습니다.
- NavMobileHeader와 GoalTodo에서 id와 role을 수정했습니다.
- 기존에 /goals 경로에서 accessToken이 만료된 상태로 다른 /goals 페이지로 이동시 예기치 않은 에러(error.tsx) 파일로 이동하던 현상을 refreshToken이 있으면 재발급하도록 수정해서 에러 페이지로 이동하지 않도록 변경했습니다.

## 📸 스크린샷 / GIF / Link
| 기존   | 수정 |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/6cf3880b-4b04-419c-9dcb-bb1bd656e007) |  ![image](https://github.com/user-attachments/assets/4dbe271b-193e-4b31-bab0-72b73cff1051)  |
| ![image](https://github.com/user-attachments/assets/db052695-49b6-4a9e-975c-6b6c5a1a4ca9) | ![image](https://github.com/user-attachments/assets/190e2b53-3678-4208-87f8-3abf2c9b744a)  |


close #370