### PR TITLE
[ 목표 ] Nav, 최근 할 일, 새 할 일 모달 목표 상태 동일하도록 수정

### DIFF
--- a/lib/hooks/useAddGoalMutation.ts
+++ b/lib/hooks/useAddGoalMutation.ts
@@ -18,7 +18,7 @@ export const useAddGoalMutation = () => {
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['goals'] });
+      queryClient.refetchQueries({ queryKey: ['goals'] });
       toast.toast({
         title: '목표가 생성되었습니다.',
         variant: 'success',

--- a/lib/hooks/useDeleteGoalMutation.ts
+++ b/lib/hooks/useDeleteGoalMutation.ts
@@ -21,8 +21,8 @@ export const useDeleteGoalMutation = () => {
         title: '목표가 삭제되었습니다.',
         variant: 'success',
       });
-      queryClient.invalidateQueries({ queryKey: ['goals'] });
       queryClient.refetchQueries({ queryKey: ['goals'] });
+      queryClient.refetchQueries({ queryKey: ['todos'] });
     },
     onError: (error) => {
       toast.toast({


### PR DESCRIPTION
## ✅ 작업 내용
최종발표에서 강사님께서 피드백 주신 다음 내용들을 수정했습니다.
- nav로 목표 삭제시 대시보드 최근 할일에 여전히 해당 할일과 목표가 남아있는 오류
  - 삭제 후 goals와 todos를 refetchQueries 하도록 수정했습니다.
- nav로 목표 추가 후 간헐적으로 새 할일 모달 목표 셀렉터에 해당 목표가 보이지 않는 오류
  - invalidateQueries 대신 refetchQueries로 바로 데이터를 가져오도록 수정했습니다.

## 📸 스크린샷 / GIF / Link
![Kapture 2024-11-30 at 16 37 54](https://github.com/user-attachments/assets/9dd9d89e-d7e6-49a6-8fbd-764aa5ad94fc)

close #373 
