### PR TITLE
[ 피드백 ] 페이지 컨테이너 수정 및 레이아웃 쓸데없는 div제거

### DIFF
--- a/app/(nav)/dashboard/layout.tsx
+++ b/app/(nav)/dashboard/layout.tsx
@@ -9,9 +9,5 @@ export default function Layout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return (
-    <div>
-      <div>{children}</div>
-    </div>
-  );
+  return <>{children}</>;
 }

--- a/app/(nav)/dashboard/page.tsx
+++ b/app/(nav)/dashboard/page.tsx
@@ -1,4 +1,3 @@
-import PageContainer from '@/components/common/pageLayout/PageContainer';
 import PageHeader from '@/components/common/pageLayout/PageHeader';
 import GoalTodo from '@/components/dashboard/GoalTodo';
 import Progress from '@/components/dashboard/Progress';
@@ -6,7 +5,7 @@ import RecentTodo from '@/components/dashboard/RecentTodo';
 
 export default function DashboardPage() {
   return (
-    <PageContainer className={'max-w-[1200px] gap-4 flex flex-col'}>
+    <>
       <div className='hidden sm:block lg:block'>
         <PageHeader title='대시보드' />
       </div>
@@ -15,6 +14,6 @@ export default function DashboardPage() {
         <Progress />
       </div>
       <GoalTodo />
-    </PageContainer>
+    </>
   );
 }

--- a/app/(nav)/goals/[goalId]/layout.tsx
+++ b/app/(nav)/goals/[goalId]/layout.tsx
@@ -9,9 +9,5 @@ export default function Layout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return (
-    <div>
-      <div>{children}</div>
-    </div>
-  );
+  return <>{children}</>;
 }

--- a/app/(nav)/goals/[goalId]/page.tsx
+++ b/app/(nav)/goals/[goalId]/page.tsx
@@ -1,5 +1,4 @@
 import GoalTitleProgress from '@/components/goals/GoalTitleWithProgress';
-import PageContainer from '@/components/common/pageLayout/PageContainer';
 import PageHeader from '@/components/common/pageLayout/PageHeader';
 import TodoItemsGoal from '@/components/goals/TodoItemsGoal';
 import baseFetch from '@/lib/api/baseFetch';
@@ -22,7 +21,7 @@ export default async function GoalDetailPage({ params }: { params: { goalId: str
   }
 
   return (
-    <PageContainer className={'max-w-[1200px] flex flex-col gap-4'}>
+    <div className='flex flex-col gap-4'>
       <div className='hidden sm:block lg:block'>
         <PageHeader title='목표' />
       </div>
@@ -43,6 +42,6 @@ export default async function GoalDetailPage({ params }: { params: { goalId: str
       <div className='flex flex-col'>
         <TodoItemsGoal goalId={+params.goalId} />
       </div>
-    </PageContainer>
+    </div>
   );
 }

--- a/app/(nav)/layout.tsx
+++ b/app/(nav)/layout.tsx
@@ -1,3 +1,4 @@
+import PageContainer from '@/components/common/pageLayout/PageContainer';
 import Nav from '@/components/nav/Nav';
 import ScrollToTop from '@/components/ScrollToTop';
 
@@ -9,7 +10,9 @@ export default function NavLayout({
   return (
     <div className='flex flex-col min-h-screen sm:flex-row lg:flex-row'>
       <Nav />
-      <div className='flex-1'>{children}</div>
+      <div className='flex-1'>
+        <PageContainer>{children}</PageContainer>
+      </div>
       <ScrollToTop />
     </div>
   );

--- a/app/(nav)/notes/[goalId]/layout.tsx
+++ b/app/(nav)/notes/[goalId]/layout.tsx
@@ -9,9 +9,5 @@ export default function Layout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return (
-    <div>
-      <div>{children}</div>
-    </div>
-  );
+  return <>{children}</>;
 }

--- a/app/(nav)/notes/[goalId]/page.tsx
+++ b/app/(nav)/notes/[goalId]/page.tsx
@@ -1,4 +1,3 @@
-import PageContainer from '@/components/common/pageLayout/PageContainer';
 import PageHeader from '@/components/common/pageLayout/PageHeader';
 import NotesContent from '@/components/notes/NotesContent';
 import baseFetch from '@/lib/api/baseFetch';
@@ -24,9 +23,9 @@ export default async function Notes({ params }: { params: { goalId: string } }) 
   );
 
   return (
-    <PageContainer>
+    <>
       <PageHeader title='노트 모아보기' />
       <NotesContent goalData={goalData} goalId={params.goalId} notesInitialData={notesInitialData} />
-    </PageContainer>
+    </>
   );
 }

--- a/app/(nav)/todos/[todoId]/_view/NoteFormSection.tsx
+++ b/app/(nav)/todos/[todoId]/_view/NoteFormSection.tsx
@@ -136,7 +136,7 @@ const NoteFormSection = ({
       noteId={noteId}
       saveButtonRef={saveButtonRef}
       onChangeSavedToast={onChangeSavedToast}
-      className='flex flex-col h-full'
+      className='flex flex-col grow h-full'
     >
       <div className='flex w-full items-center mb-4'>
         <h1 className='grow text-slate-900 font-semibold text-lg'>노트 작성</h1>

--- a/app/(nav)/todos/[todoId]/create/layout.tsx
+++ b/app/(nav)/todos/[todoId]/create/layout.tsx
@@ -9,9 +9,5 @@ export default function Layout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return (
-    <div>
-      <div>{children}</div>
-    </div>
-  );
+  return <>{children}</>;
 }

--- a/app/(nav)/todos/[todoId]/create/page.tsx
+++ b/app/(nav)/todos/[todoId]/create/page.tsx
@@ -1,9 +1,5 @@
 import NoteFormSections from '../_view/NoteFormSections';
 
 export default function Page() {
-  return (
-    <main className='lg:flex h-[calc(100vh-3.5rem)] sm:h-screen overflow-auto'>
-      <NoteFormSections />
-    </main>
-  );
+  return <NoteFormSections />;
 }

--- a/app/(nav)/todos/[todoId]/note/[noteId]/page.tsx
+++ b/app/(nav)/todos/[todoId]/note/[noteId]/page.tsx
@@ -18,9 +18,5 @@ export default async function Page({ params }: { params: { noteId: string } }) {
   }
 
   const { title, content, linkUrl } = response;
-  return (
-    <main className='lg:flex h-[calc(100vh-3.5rem)] sm:h-screen overflow-auto'>
-      <NoteFormSections title={title} content={content} linkUrl={linkUrl ?? ''} method='PATCH' noteId={noteId} />
-    </main>
-  );
+  return <NoteFormSections title={title} content={content} linkUrl={linkUrl ?? ''} method='PATCH' noteId={noteId} />;
 }

--- a/app/(nav)/todos/layout.tsx
+++ b/app/(nav)/todos/layout.tsx
@@ -9,9 +9,5 @@ export default function Layout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return (
-    <div>
-      <div>{children}</div>
-    </div>
-  );
+  return <>{children}</>;
 }

--- a/app/(nav)/todos/page.tsx
+++ b/app/(nav)/todos/page.tsx
@@ -1,7 +1,6 @@
 import TodosContent from '@/components/allTodos/TodosContent';
 import { TodosProvider } from '@/components/allTodos/TodosContext';
 import TodosHeader from '@/components/allTodos/TodosHeader';
-import PageContainer from '@/components/common/pageLayout/PageContainer';
 import baseFetch from '@/lib/api/baseFetch';
 import { GetTodosResponse } from '@/lib/types/todo';
 import { cookies } from 'next/headers';
@@ -19,11 +18,11 @@ export default async function Alltodos({ searchParams }: { searchParams: { statu
     cache: 'no-store',
   });
   return (
-    <PageContainer>
+    <>
       <TodosProvider>
         <TodosHeader />
         <TodosContent TodosInitialData={TodosInitialData} />
       </TodosProvider>
-    </PageContainer>
+    </>
   );
 }

--- a/app/login/layout.tsx
+++ b/app/login/layout.tsx
@@ -9,9 +9,5 @@ export default function Layout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return (
-    <div>
-      <div>{children}</div>
-    </div>
-  );
+  return <>{children}</>;
 }

--- a/app/signup/layout.tsx
+++ b/app/signup/layout.tsx
@@ -9,9 +9,5 @@ export default function Layout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return (
-    <div>
-      <div>{children}</div>
-    </div>
-  );
+  return <>{children}</>;
 }

--- a/components/common/pageLayout/PageContainer.tsx
+++ b/components/common/pageLayout/PageContainer.tsx
@@ -1,19 +1,51 @@
+'use client';
+
 import { type ReactNode } from 'react';
 import { clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import { usePathname } from 'next/navigation';
 
 interface PageContainerProps {
   children: ReactNode;
-  className?: string;
-  containerClassName?: string;
+  pageUrl?: string;
 }
 
-const PageContainer = ({ children, className = '', containerClassName = '' }: PageContainerProps) => {
+const PageContainer = ({ children }: PageContainerProps) => {
+  const pageUrl = usePathname();
+  function getTransformedUrl(pathname: string) {
+    if (pathname.includes('/todos') && pathname.includes('/note')) {
+      return '/note-edit';
+    } else if (pathname.includes('/todos') && pathname.includes('/create')) {
+      return '/note-create';
+    } else if (pathname.includes('/dashboard')) {
+      return '/dashboard';
+    } else if (pathname.includes('/goals')) {
+      return '/goals';
+    }
+    return 'default';
+  }
+
+  const transformedUrl = getTransformedUrl(pageUrl);
+
+  const containerStyle = {
+    default: 'bg-slate-100',
+    '/note-create': 'bg-white flex',
+    '/note-edit': 'bg-white flex',
+    '/dashboard': 'bg-slate-100',
+    '/goals': 'bg-slate-100',
+  };
+
+  const sectionStyle = {
+    default: 'max-w-[800px]',
+    '/dashboard': 'max-w-[1200px]',
+    '/note-create': 'max-w-[800px] grow',
+    '/note-edit': 'max-w-[800px] grow',
+    '/goals': 'max-w-[1200px]',
+  };
+
   return (
-    <main
-      className={twMerge(clsx('bg-slate-100 w-full min-h-[calc(100vh-3.5rem)] sm:min-h-screen', containerClassName))}
-    >
-      <section className={twMerge(clsx('lg:px-20 sm:px-6 px-4 py-6 max-w-[792px] h-full', className))}>
+    <main className={twMerge(clsx('w-full h-screen pt-[3.5rem] sm:pt-0', containerStyle[transformedUrl]))}>
+      <section className={twMerge(clsx('h-full lg:px-20 sm:px-6 px-4 py-6', sectionStyle[transformedUrl]))}>
         {children}
       </section>
     </main>

--- a/components/nav/NavMobileHeader.tsx
+++ b/components/nav/NavMobileHeader.tsx
@@ -17,7 +17,7 @@ const NavMobileHeader: React.FC<NavMobileHeader> = ({ currentPageLabel, handleTo
   }, [pathname]);
   return (
     <>
-      <nav aria-label='모바일 헤더' className=' sticky top-0 left-0 right-0 z-10'>
+      <nav aria-label='모바일 헤더' className='fixed top-0 left-0 right-0 z-10'>
         <NavSection className='flex sm:hidden flex-row px-[14px] py-4 justify-normal backdrop-saturate-180 backdrop-blur-sm'>
           <div
             role='button'


### PR DESCRIPTION
close #375 

## ✅ 작업 내용
1. 레이아웃에 있던 쓸데없는 div를 제거하였습니다. 

2. 페이지 컨테이너 공통 컴포넌트를 레이아웃에 한번 사용하여 관련 모든 페이지에 적용하게 하였습니다
- usePathname 으로 각 페이지를 식별하게 하여 스타일 차이를 주었습니다.
- 수정된 페이지 컴포넌트 적용에 맞게 각각 페이지를 수정하였습니다.
- 노트 수정, 추가 페이지에서는 자식에게 높이가 잘 전달될 수 있게 스타일을 추가해주었습니다.
- 기존 nav 모바일 헤더를 stick에서 fixed로 바꾸었고 그에 맡게 수정하였습니다 (이유: 기존에는 stick 값만큼을 h를 여러 곳에서 빼줘야 했지만 이제는 fix값만큼 pt만 주면 되어 더 직관적으로 보임)

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항

## ✍ 궁금한 것
